### PR TITLE
🆙 golang 1.23.0にダウングレード

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-alpine3.20 AS builder
+FROM golang:1.23.0-alpine AS builder
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/neko-dream/server
 
-go 1.23.4
+go 1.23.0
 
 require (
 	braces.dev/errtrace v0.3.0


### PR DESCRIPTION
koyebのBuild Packが1.23.4に対応していなかったため、元に戻す。