### PR TITLE
🚑 文字列はutf8.RuneCountInStringでカウントするようにした

### DIFF
--- a/internal/domain/model/opinion/opinion.go
+++ b/internal/domain/model/opinion/opinion.go
@@ -58,13 +58,13 @@ func NewOpinion(
 	if content == "" {
 		return nil, messages.OpinionContentBadLength
 	}
-	if utf8.RuneCountInString(content) > 140 && utf8.RuneCountInString(content) < 5 {
+	if utf8.RuneCountInString(content) > 140 || utf8.RuneCountInString(content) < 5 {
 		return nil, messages.OpinionContentBadLength
 	}
 	if parentOpinionID != nil && opinionID == *parentOpinionID {
 		return nil, messages.OpinionParentOpinionIDIsSame
 	}
-	if title != nil && utf8.RuneCountInString(*title) > 50 && utf8.RuneCountInString(*title) < 5 {
+	if title != nil && utf8.RuneCountInString(*title) > 50 || utf8.RuneCountInString(*title) < 5 {
 		return nil, messages.OpinionTitleBadLength
 	}
 

--- a/internal/domain/model/opinion/opinion.go
+++ b/internal/domain/model/opinion/opinion.go
@@ -55,16 +55,13 @@ func NewOpinion(
 	createdAt time.Time,
 	referenceURL *string,
 ) (*Opinion, error) {
-	if content == "" {
-		return nil, messages.OpinionContentBadLength
-	}
 	if utf8.RuneCountInString(content) > 140 || utf8.RuneCountInString(content) < 5 {
 		return nil, messages.OpinionContentBadLength
 	}
 	if parentOpinionID != nil && opinionID == *parentOpinionID {
 		return nil, messages.OpinionParentOpinionIDIsSame
 	}
-	if title != nil && utf8.RuneCountInString(*title) > 50 || utf8.RuneCountInString(*title) < 5 {
+	if title != nil && (utf8.RuneCountInString(*title) > 50 || utf8.RuneCountInString(*title) < 5) {
 		return nil, messages.OpinionTitleBadLength
 	}
 

--- a/internal/domain/model/opinion/opinion.go
+++ b/internal/domain/model/opinion/opinion.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"mime/multipart"
 	"time"
+	"unicode/utf8"
 
 	"github.com/neko-dream/server/internal/domain/messages"
 	"github.com/neko-dream/server/internal/domain/model/shared"
@@ -57,13 +58,13 @@ func NewOpinion(
 	if content == "" {
 		return nil, messages.OpinionContentBadLength
 	}
-	if len(content) > 140 && len(content) < 5 {
+	if utf8.RuneCountInString(content) > 140 && utf8.RuneCountInString(content) < 5 {
 		return nil, messages.OpinionContentBadLength
 	}
 	if parentOpinionID != nil && opinionID == *parentOpinionID {
 		return nil, messages.OpinionParentOpinionIDIsSame
 	}
-	if title != nil && len(*title) > 50 && len(*title) < 5 {
+	if title != nil && utf8.RuneCountInString(*title) > 50 && utf8.RuneCountInString(*title) < 5 {
 		return nil, messages.OpinionTitleBadLength
 	}
 

--- a/internal/domain/model/timeline_actions/action_item.go
+++ b/internal/domain/model/timeline_actions/action_item.go
@@ -3,6 +3,7 @@ package timelineactions
 import (
 	"context"
 	"time"
+	"unicode/utf8"
 
 	"github.com/neko-dream/server/internal/domain/messages"
 	"github.com/neko-dream/server/internal/domain/model/shared"
@@ -53,7 +54,7 @@ func NewActionItem(
 		return nil, messages.ActionItemInvalidStatus
 	}
 
-	if len(content) < 1 || len(content) > 40 {
+	if utf8.RuneCountInString(content) < 1 || utf8.RuneCountInString(content) > 40 {
 		return nil, messages.ActionItemInvalidContent
 	}
 
@@ -69,7 +70,7 @@ func NewActionItem(
 }
 
 func (a *ActionItem) UpdateContent(content string) error {
-	if len(content) < 1 || len(content) > 40 {
+	if utf8.RuneCountInString(content) < 1 || utf8.RuneCountInString(content) > 40 {
 		return messages.ActionItemInvalidContent
 	}
 

--- a/internal/domain/model/user/user.go
+++ b/internal/domain/model/user/user.go
@@ -3,6 +3,7 @@ package user
 import (
 	"context"
 	"mime/multipart"
+	"unicode/utf8"
 
 	"github.com/neko-dream/server/internal/domain/messages"
 	"github.com/neko-dream/server/internal/domain/model/auth"
@@ -65,10 +66,10 @@ func (u *User) SetDisplayID(id string) error {
 	if id == "" {
 		return messages.UserDisplayIDInvalidError
 	}
-	if len([]rune(id)) > 30 {
+	if utf8.RuneCountInString(id) > 30 {
 		return messages.UserDisplayIDTooLong
 	}
-	if len([]rune(id)) < 4 {
+	if utf8.RuneCountInString(id) < 4 {
 		return messages.UserDisplayIDTooShort
 	}
 	u.displayID = lo.ToPtr(id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **バグ修正**
	- 複数バイト文字の長さ検証を改善
	- Unicode文字列の長さ計算を`utf8.RuneCountInString`に更新
	- 文字列長の検証ロジックを正確に修正

- **改善点**
	- マルチバイト文字に対する文字列長の検証を最適化
	- ユニコード文字の正確な文字数カウントを実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->