### PR TITLE
TalkSession制限関係で上手く値を取れていなかったため修正

### DIFF
--- a/internal/domain/model/image/meta/meta_test.go
+++ b/internal/domain/model/image/meta/meta_test.go
@@ -213,7 +213,7 @@ func TestNewImageForProfile(t *testing.T) {
 	meta, err := NewImageForProfile(ctx, userID, f)
 	assert.NoError(t, err)
 	assert.NotNil(t, meta)
-	assert.Equal(t, "users/"+userID.String()+".jpg", meta.Key)
+	assert.Equal(t, "u/"+userID.String()+".jpg", meta.Key)
 	assert.Equal(t, 100, meta.Width)
 	assert.Equal(t, 50, meta.Height)
 	assert.Equal(t, "image/png", meta.Extension.Value)

--- a/internal/domain/model/talksession/restriction.go
+++ b/internal/domain/model/talksession/restriction.go
@@ -1,6 +1,9 @@
 package talksession
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/neko-dream/server/internal/domain/messages"
 	"github.com/neko-dream/server/internal/domain/model/user"
 )
@@ -63,12 +66,12 @@ var (
 	}
 )
 
-func (k RestrictionAttributeKey) RestrictionAttribute() RestrictionAttribute {
-	return RestrictionAttributeKeyMap[k]
+func (k *RestrictionAttributeKey) RestrictionAttribute() RestrictionAttribute {
+	return RestrictionAttributeKeyMap[*k]
 }
 
-func (k RestrictionAttributeKey) IsValid() bool {
-	_, ok := RestrictionAttributeKeyMap[k]
+func (k *RestrictionAttributeKey) IsValid() bool {
+	_, ok := RestrictionAttributeKeyMap[*k]
 	return ok
 }
 
@@ -81,3 +84,26 @@ var (
 )
 
 type Restrictions []string
+
+func (s *Restrictions) Scan(src interface{}) error {
+	if src == nil {
+		*s = nil
+		return nil
+	}
+
+	switch v := src.(type) {
+	case []byte:
+		return json.Unmarshal(v, s)
+	case string:
+		return json.Unmarshal([]byte(v), s)
+	default:
+		return fmt.Errorf("unsupported type for StringSlice: %T", src)
+	}
+}
+
+func (s Restrictions) Value() (interface{}, error) {
+	if s == nil {
+		return nil, nil
+	}
+	return json.Marshal(s)
+}

--- a/internal/infrastructure/crypto/user_encryptor_test.go
+++ b/internal/infrastructure/crypto/user_encryptor_test.go
@@ -59,7 +59,7 @@ func TestEncryptUserDemographics(t *testing.T) {
 				demoID,
 				nil,              // 生年
 				nil,              // 職業
-				lo.ToPtr(""),     // 性別
+				lo.ToPtr("男性"),   // 性別
 				lo.ToPtr("世田谷区"), // 都市
 				nil,              // 世帯人数
 				nil,              // 都道府県

--- a/internal/infrastructure/persistence/repository/talk_session_repository.go
+++ b/internal/infrastructure/persistence/repository/talk_session_repository.go
@@ -64,7 +64,7 @@ func (t *talkSessionRepository) Create(ctx context.Context, talkSession *talkses
 		ScheduledEndTime: talkSession.ScheduledEndTime(),
 		Prefecture:       prefecture,
 		City:             city,
-		Restrictions:     restrictions,
+		Restrictions:     talksession.Restrictions(restrictions),
 	}); err != nil {
 		return errtrace.Wrap(err)
 	}

--- a/internal/presentation/handler/talk_session_handler.go
+++ b/internal/presentation/handler/talk_session_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"strings"
 	"time"
 
 	"braces.dev/errtrace"
@@ -205,7 +206,8 @@ func (t *talkSessionHandler) GetOpenedTalkSession(ctx context.Context, params oa
 		}
 		var restrictions []oas.GetOpenedTalkSessionOKTalkSessionsItemTalkSessionRestrictionsItem
 		for _, restriction := range talkSession.TalkSession.Restrictions {
-			attr := talksession.RestrictionAttributeKey(restriction).RestrictionAttribute()
+			res := talksession.RestrictionAttributeKey(restriction)
+			attr := res.RestrictionAttribute()
 			restrictions = append(restrictions, oas.GetOpenedTalkSessionOKTalkSessionsItemTalkSessionRestrictionsItem{
 				Key:         string(attr.Key),
 				Description: attr.Description,
@@ -272,6 +274,12 @@ func (t *talkSessionHandler) CreateTalkSession(ctx context.Context, req oas.OptC
 		utils.HandleError(ctx, err, "claim.UserID")
 		return nil, messages.ForbiddenError
 	}
+	var restrictionStrings []string
+	if req.Value.Restrictions != nil {
+		if sl := strings.Split(strings.Join(req.Value.Restrictions, ","), ","); len(sl) > 0 {
+			restrictionStrings = sl
+		}
+	}
 
 	out, err := t.startTalkSessionCommand.Execute(ctx, talksession_command.StartTalkSessionCommandInput{
 		Theme:            req.Value.Theme,
@@ -283,6 +291,7 @@ func (t *talkSessionHandler) CreateTalkSession(ctx context.Context, req oas.OptC
 		Longitude:        utils.ToPtrIfNotNullValue(!req.Value.Longitude.IsSet(), req.Value.Longitude.Value),
 		City:             utils.ToPtrIfNotNullValue(!req.Value.City.IsSet(), req.Value.City.Value),
 		Prefecture:       utils.ToPtrIfNotNullValue(!req.Value.Prefecture.IsSet(), req.Value.Prefecture.Value),
+		Restrictions:     restrictionStrings,
 	})
 	if err != nil {
 		return nil, errtrace.Wrap(err)
@@ -300,7 +309,8 @@ func (t *talkSessionHandler) CreateTalkSession(ctx context.Context, req oas.OptC
 	}
 	var restrictions []oas.CreateTalkSessionOKRestrictionsItem
 	for _, restriction := range out.TalkSession.Restrictions {
-		attr := talksession.RestrictionAttributeKey(restriction).RestrictionAttribute()
+		res := talksession.RestrictionAttributeKey(restriction)
+		attr := res.RestrictionAttribute()
 		restrictions = append(restrictions, oas.CreateTalkSessionOKRestrictionsItem{
 			Key:         string(attr.Key),
 			Description: attr.Description,
@@ -359,7 +369,8 @@ func (t *talkSessionHandler) GetTalkSessionDetail(ctx context.Context, params oa
 	}
 	var restrictions []oas.GetTalkSessionDetailOKRestrictionsItem
 	for _, restriction := range out.TalkSession.Restrictions {
-		attr := talksession.RestrictionAttributeKey(restriction).RestrictionAttribute()
+		res := talksession.RestrictionAttributeKey(restriction)
+		attr := res.RestrictionAttribute()
 		restrictions = append(restrictions, oas.GetTalkSessionDetailOKRestrictionsItem{
 			Key:         string(attr.Key),
 			Description: attr.Description,
@@ -448,7 +459,8 @@ func (t *talkSessionHandler) GetTalkSessionList(ctx context.Context, params oas.
 		}
 		var restrictions []oas.GetTalkSessionListOKTalkSessionsItemTalkSessionRestrictionsItem
 		for _, restriction := range talkSession.TalkSession.Restrictions {
-			attr := talksession.RestrictionAttributeKey(restriction).RestrictionAttribute()
+			res := talksession.RestrictionAttributeKey(restriction)
+			attr := res.RestrictionAttribute()
 			restrictions = append(restrictions, oas.GetTalkSessionListOKTalkSessionsItemTalkSessionRestrictionsItem{
 				Key:         string(attr.Key),
 				Description: attr.Description,

--- a/internal/usecase/command/talksession_command/start_talksession_command.go
+++ b/internal/usecase/command/talksession_command/start_talksession_command.go
@@ -32,6 +32,7 @@ type (
 		Longitude        *float64
 		City             *string
 		Prefecture       *string
+		Restrictions     []string
 	}
 
 	StartTalkSessionCommandOutput struct {
@@ -105,6 +106,11 @@ func (i *startTalkSessionCommandHandler) Execute(ctx context.Context, input Star
 			input.City,
 			input.Prefecture,
 		)
+		if input.Restrictions != nil {
+			if err := talkSession.UpdateRestrictions(ctx, input.Restrictions); err != nil {
+				return errtrace.Wrap(err)
+			}
+		}
 
 		if err := i.TalkSessionRepository.Create(ctx, talkSession); err != nil {
 			utils.HandleError(ctx, err, "TalkSessionRepository.Create")
@@ -124,6 +130,9 @@ func (i *startTalkSessionCommandHandler) Execute(ctx context.Context, input Star
 		}
 		output.Latitude = input.Latitude
 		output.Longitude = input.Longitude
+		if input.Restrictions != nil {
+			output.Restrictions = input.Restrictions
+		}
 
 		// オーナーのユーザー情報を取得
 		ownerUser, err := i.UserRepository.FindByID(ctx, input.OwnerID)

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -10,6 +10,7 @@ sql:
               emit_sql_as_comment: true
               overrides:
                 - column: "talk_sessions.restrictions"
+                  db_type: "jsonb"
                   go_type:
                     import: "github.com/neko-dream/server/internal/domain/model/talksession"
                     type: "Restrictions"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- トークセッション作成時に、複数の制約条件（Restrictions）を指定できるようになり、指定した制約が出力に反映されます。

- **リファクタ**
	- トークセッションにおける制約条件の処理ロジックを見直し、データ変換や入力処理の一貫性と保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->