### PR TITLE
Restrictionsの順番を固定

### DIFF
--- a/internal/domain/model/talksession/restriction.go
+++ b/internal/domain/model/talksession/restriction.go
@@ -11,7 +11,8 @@ import (
 type RestrictionAttribute struct {
 	Key         RestrictionAttributeKey
 	Description string
-	Fn          func(user user.User) bool
+	// IsSatisfied ユーザーが条件を満たしているかを判定する
+	IsSatisfied func(user user.User) bool
 }
 
 type RestrictionAttributeKey string
@@ -25,25 +26,25 @@ const (
 
 var (
 	RestrictionAttributeKeyMap = map[RestrictionAttributeKey]RestrictionAttribute{
-		DemographicsCity: {Key: DemographicsCity, Description: "市区町村", Fn: func(user user.User) bool {
+		DemographicsCity: {Key: DemographicsCity, Description: "市区町村", IsSatisfied: func(user user.User) bool {
 			if user.Demographics() == nil {
 				return false
 			}
 			return user.Demographics().City() != nil
 		}},
-		DemographicsPrefecture: {Key: DemographicsPrefecture, Description: "都道府県", Fn: func(user user.User) bool {
+		DemographicsPrefecture: {Key: DemographicsPrefecture, Description: "都道府県", IsSatisfied: func(user user.User) bool {
 			if user.Demographics() == nil {
 				return false
 			}
 			return user.Demographics().Prefecture() != nil
 		}},
-		DemographicsGender: {Key: DemographicsGender, Description: "性別", Fn: func(user user.User) bool {
+		DemographicsGender: {Key: DemographicsGender, Description: "性別", IsSatisfied: func(user user.User) bool {
 			if user.Demographics() == nil {
 				return false
 			}
 			return user.Demographics().Gender() != nil
 		}},
-		DemographicsBirth: {Key: DemographicsBirth, Description: "誕生年", Fn: func(user user.User) bool {
+		DemographicsBirth: {Key: DemographicsBirth, Description: "誕生年", IsSatisfied: func(user user.User) bool {
 			if user.Demographics() == nil {
 				return false
 			}

--- a/internal/domain/model/talksession/restriction.go
+++ b/internal/domain/model/talksession/restriction.go
@@ -11,6 +11,7 @@ import (
 type RestrictionAttribute struct {
 	Key         RestrictionAttributeKey
 	Description string
+	Order       int
 	// IsSatisfied ユーザーが条件を満たしているかを判定する
 	IsSatisfied func(user user.User) bool
 }
@@ -26,30 +27,46 @@ const (
 
 var (
 	RestrictionAttributeKeyMap = map[RestrictionAttributeKey]RestrictionAttribute{
-		DemographicsCity: {Key: DemographicsCity, Description: "市区町村", IsSatisfied: func(user user.User) bool {
-			if user.Demographics() == nil {
-				return false
-			}
-			return user.Demographics().City() != nil
-		}},
-		DemographicsPrefecture: {Key: DemographicsPrefecture, Description: "都道府県", IsSatisfied: func(user user.User) bool {
-			if user.Demographics() == nil {
-				return false
-			}
-			return user.Demographics().Prefecture() != nil
-		}},
-		DemographicsGender: {Key: DemographicsGender, Description: "性別", IsSatisfied: func(user user.User) bool {
-			if user.Demographics() == nil {
-				return false
-			}
-			return user.Demographics().Gender() != nil
-		}},
-		DemographicsBirth: {Key: DemographicsBirth, Description: "誕生年", IsSatisfied: func(user user.User) bool {
-			if user.Demographics() == nil {
-				return false
-			}
-			return user.Demographics().YearOfBirth() != nil
-		}},
+		DemographicsGender: {
+			Key:         DemographicsGender,
+			Description: "性別",
+			Order:       0,
+			IsSatisfied: func(user user.User) bool {
+				if user.Demographics() == nil {
+					return false
+				}
+				return user.Demographics().Gender() != nil
+			}},
+		DemographicsBirth: {
+			Key:         DemographicsBirth,
+			Description: "誕生年",
+			Order:       1,
+			IsSatisfied: func(user user.User) bool {
+				if user.Demographics() == nil {
+					return false
+				}
+				return user.Demographics().YearOfBirth() != nil
+			}},
+		DemographicsCity: {
+			Key:         DemographicsCity,
+			Description: "市区町村",
+			Order:       2,
+			IsSatisfied: func(user user.User) bool {
+				if user.Demographics() == nil {
+					return false
+				}
+				return user.Demographics().City() != nil
+			}},
+		DemographicsPrefecture: {
+			Key:         DemographicsPrefecture,
+			Description: "都道府県",
+			Order:       3,
+			IsSatisfied: func(user user.User) bool {
+				if user.Demographics() == nil {
+					return false
+				}
+				return user.Demographics().Prefecture() != nil
+			}},
 	}
 )
 

--- a/internal/domain/service/talksession_access_control.go
+++ b/internal/domain/service/talksession_access_control.go
@@ -70,7 +70,7 @@ func (t *talkSessionAccessControl) CanUserJoin(ctx context.Context, talkSessionI
 	// 参加制限がある場合は、ユーザーが参加可能かを判定し、もし参加制限に引っかかる場合はエラーを返す
 	var restrictions []talksession.RestrictionAttribute
 	for _, restriction := range talkSession.Restrictions() {
-		if !restriction.Fn(*user) {
+		if !restriction.IsSatisfied(*user) {
 			restrictions = append(restrictions, *restriction)
 		}
 	}

--- a/internal/infrastructure/persistence/query/talksession/get_restrictions_query.go
+++ b/internal/infrastructure/persistence/query/talksession/get_restrictions_query.go
@@ -2,6 +2,7 @@ package talksession_query
 
 import (
 	"context"
+	"sort"
 
 	ts "github.com/neko-dream/server/internal/domain/model/talksession"
 	"github.com/neko-dream/server/internal/usecase/query/talksession"
@@ -27,6 +28,11 @@ func (q *getRestrictionsQuery) Execute(ctx context.Context) (*talksession.GetRes
 	for _, restriction := range restrictionAttributeMap {
 		restrictions = append(restrictions, restriction)
 	}
+
+	// sort
+	sort.Slice(restrictions, func(i, j int) bool {
+		return restrictions[i].Order < restrictions[j].Order
+	})
 
 	return &talksession.GetRestrictionsOutput{
 		Restrictions: restrictions,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - トークセッションの制限評価が改善され、ユーザーが参加可能かを判断するロジックがより明確になりました。
  - 制限の優先順位に基づいた処理順序が導入され、一貫したアクセス制御が実現されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->