### PR TITLE
TalkSessionIDをBodyで受け取る意見投稿エンドポイント

### DIFF
--- a/api/target/apidog.openapi.yaml
+++ b/api/target/apidog.openapi.yaml
@@ -364,6 +364,149 @@
         "x-ogen-operation-group": "Vote"
       }
     },
+    "/opinions": {
+      "post": {
+        "summary": "セッションに対して意見投稿 or 意見に対するリプライ",
+        "deprecated": false,
+        "description": "parentOpinionIDがなければルートの意見として投稿される\nparentOpinionIDがない場合はtalkSessionIDが必須",
+        "operationId": "postOpinionPost2",
+        "tags": [
+          "opinion"
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "talkSessionID": {
+                    "type": "string",
+                    "example": "",
+                    "nullable": true
+                  },
+                  "parentOpinionID": {
+                    "type": "string",
+                    "description": "これがある場合はリプライとみなす。これがない場合はTalkSessionIDが必須。",
+                    "example": "",
+                    "nullable": true
+                  },
+                  "title": {
+                    "type": "string",
+                    "example": "",
+                    "nullable": true
+                  },
+                  "opinionContent": {
+                    "type": "string",
+                    "maxLength": 140,
+                    "example": ""
+                  },
+                  "referenceURL": {
+                    "type": "string",
+                    "format": "url",
+                    "example": "",
+                    "nullable": true
+                  },
+                  "picture": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "参考画像。4MiBまで",
+                    "example": ""
+                  }
+                },
+                "required": [
+                  "opinionContent"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            },
+            "headers": {}
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "code",
+                    "message"
+                  ]
+                },
+                "examples": {
+                  "1": {
+                    "summary": "internal",
+                    "value": {
+                      "code": "GENERAL-000",
+                      "message": "INTERNAL SERVER ERROR."
+                    }
+                  }
+                }
+              }
+            },
+            "headers": {}
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "code",
+                    "message"
+                  ]
+                },
+                "examples": {
+                  "1": {
+                    "summary": "internal",
+                    "value": {
+                      "code": "GENERAL-000",
+                      "message": "INTERNAL SERVER ERROR."
+                    }
+                  }
+                }
+              }
+            },
+            "headers": {}
+          }
+        },
+        "security": [
+          {
+            "SessionId": []
+          }
+        ],
+        "x-ogen-operation-group": "Opinion"
+      }
+    },
     "/talksessions/{talkSessionID}/opinions/{opinionID}/votes": {
       "post": {
         "summary": "意思表明API",

--- a/internal/presentation/oas/oas_interfaces_gen.go
+++ b/internal/presentation/oas/oas_interfaces_gen.go
@@ -105,6 +105,10 @@ type PostImageRes interface {
 	postImageRes()
 }
 
+type PostOpinionPost2Res interface {
+	postOpinionPost2Res()
+}
+
 type PostOpinionPostRes interface {
 	postOpinionPostRes()
 }

--- a/internal/presentation/oas/oas_json_gen.go
+++ b/internal/presentation/oas/oas_json_gen.go
@@ -13788,6 +13788,276 @@ func (s *PostImageOK) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *PostOpinionPost2BadRequest) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *PostOpinionPost2BadRequest) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("code")
+		e.Str(s.Code)
+	}
+	{
+		e.FieldStart("message")
+		e.Str(s.Message)
+	}
+}
+
+var jsonFieldsNameOfPostOpinionPost2BadRequest = [2]string{
+	0: "code",
+	1: "message",
+}
+
+// Decode decodes PostOpinionPost2BadRequest from json.
+func (s *PostOpinionPost2BadRequest) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode PostOpinionPost2BadRequest to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "code":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Code = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"code\"")
+			}
+		case "message":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.Message = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"message\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode PostOpinionPost2BadRequest")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfPostOpinionPost2BadRequest) {
+					name = jsonFieldsNameOfPostOpinionPost2BadRequest[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *PostOpinionPost2BadRequest) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *PostOpinionPost2BadRequest) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *PostOpinionPost2InternalServerError) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *PostOpinionPost2InternalServerError) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("code")
+		e.Str(s.Code)
+	}
+	{
+		e.FieldStart("message")
+		e.Str(s.Message)
+	}
+}
+
+var jsonFieldsNameOfPostOpinionPost2InternalServerError = [2]string{
+	0: "code",
+	1: "message",
+}
+
+// Decode decodes PostOpinionPost2InternalServerError from json.
+func (s *PostOpinionPost2InternalServerError) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode PostOpinionPost2InternalServerError to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "code":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Code = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"code\"")
+			}
+		case "message":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.Message = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"message\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode PostOpinionPost2InternalServerError")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfPostOpinionPost2InternalServerError) {
+					name = jsonFieldsNameOfPostOpinionPost2InternalServerError[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *PostOpinionPost2InternalServerError) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *PostOpinionPost2InternalServerError) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *PostOpinionPost2OK) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *PostOpinionPost2OK) encodeFields(e *jx.Encoder) {
+}
+
+var jsonFieldsNameOfPostOpinionPost2OK = [0]string{}
+
+// Decode decodes PostOpinionPost2OK from json.
+func (s *PostOpinionPost2OK) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode PostOpinionPost2OK to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		default:
+			return d.Skip()
+		}
+	}); err != nil {
+		return errors.Wrap(err, "decode PostOpinionPost2OK")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *PostOpinionPost2OK) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *PostOpinionPost2OK) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *PostOpinionPostBadRequest) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)

--- a/internal/presentation/oas/oas_request_decoders_gen.go
+++ b/internal/presentation/oas/oas_request_decoders_gen.go
@@ -1656,6 +1656,260 @@ func (s *Server) decodePostOpinionPostRequest(r *http.Request) (
 	}
 }
 
+func (s *Server) decodePostOpinionPost2Request(r *http.Request) (
+	req OptPostOpinionPost2Req,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	if _, ok := r.Header["Content-Type"]; !ok && r.ContentLength == 0 {
+		return req, close, nil
+	}
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "multipart/form-data":
+		if r.ContentLength == 0 {
+			return req, close, nil
+		}
+		if err := r.ParseMultipartForm(s.cfg.MaxMultipartMemory); err != nil {
+			return req, close, errors.Wrap(err, "parse multipart form")
+		}
+		// Remove all temporary files created by ParseMultipartForm when the request is done.
+		//
+		// Notice that the closers are called in reverse order, to match defer behavior, so
+		// any opened file will be closed before RemoveAll call.
+		closers = append(closers, r.MultipartForm.RemoveAll)
+		// Form values may be unused.
+		form := url.Values(r.MultipartForm.Value)
+		_ = form
+
+		var request OptPostOpinionPost2Req
+		{
+			var optForm PostOpinionPost2Req
+			q := uri.NewQueryDecoder(form)
+			{
+				cfg := uri.QueryParameterDecodingConfig{
+					Name:    "talkSessionID",
+					Style:   uri.QueryStyleForm,
+					Explode: true,
+				}
+				if err := q.HasParam(cfg); err == nil {
+					if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+						var optFormDotTalkSessionIDVal string
+						if err := func() error {
+							val, err := d.DecodeValue()
+							if err != nil {
+								return err
+							}
+
+							c, err := conv.ToString(val)
+							if err != nil {
+								return err
+							}
+
+							optFormDotTalkSessionIDVal = c
+							return nil
+						}(); err != nil {
+							return err
+						}
+						optForm.TalkSessionID.SetTo(optFormDotTalkSessionIDVal)
+						return nil
+					}); err != nil {
+						return req, close, errors.Wrap(err, "decode \"talkSessionID\"")
+					}
+				}
+			}
+			{
+				cfg := uri.QueryParameterDecodingConfig{
+					Name:    "parentOpinionID",
+					Style:   uri.QueryStyleForm,
+					Explode: true,
+				}
+				if err := q.HasParam(cfg); err == nil {
+					if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+						var optFormDotParentOpinionIDVal string
+						if err := func() error {
+							val, err := d.DecodeValue()
+							if err != nil {
+								return err
+							}
+
+							c, err := conv.ToString(val)
+							if err != nil {
+								return err
+							}
+
+							optFormDotParentOpinionIDVal = c
+							return nil
+						}(); err != nil {
+							return err
+						}
+						optForm.ParentOpinionID.SetTo(optFormDotParentOpinionIDVal)
+						return nil
+					}); err != nil {
+						return req, close, errors.Wrap(err, "decode \"parentOpinionID\"")
+					}
+				}
+			}
+			{
+				cfg := uri.QueryParameterDecodingConfig{
+					Name:    "title",
+					Style:   uri.QueryStyleForm,
+					Explode: true,
+				}
+				if err := q.HasParam(cfg); err == nil {
+					if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+						var optFormDotTitleVal string
+						if err := func() error {
+							val, err := d.DecodeValue()
+							if err != nil {
+								return err
+							}
+
+							c, err := conv.ToString(val)
+							if err != nil {
+								return err
+							}
+
+							optFormDotTitleVal = c
+							return nil
+						}(); err != nil {
+							return err
+						}
+						optForm.Title.SetTo(optFormDotTitleVal)
+						return nil
+					}); err != nil {
+						return req, close, errors.Wrap(err, "decode \"title\"")
+					}
+				}
+			}
+			{
+				cfg := uri.QueryParameterDecodingConfig{
+					Name:    "opinionContent",
+					Style:   uri.QueryStyleForm,
+					Explode: true,
+				}
+				if err := q.HasParam(cfg); err == nil {
+					if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToString(val)
+						if err != nil {
+							return err
+						}
+
+						optForm.OpinionContent = c
+						return nil
+					}); err != nil {
+						return req, close, errors.Wrap(err, "decode \"opinionContent\"")
+					}
+					if err := func() error {
+						if err := (validate.String{
+							MinLength:    0,
+							MinLengthSet: false,
+							MaxLength:    140,
+							MaxLengthSet: true,
+							Email:        false,
+							Hostname:     false,
+							Regex:        nil,
+						}).Validate(string(optForm.OpinionContent)); err != nil {
+							return errors.Wrap(err, "string")
+						}
+						return nil
+					}(); err != nil {
+						return req, close, errors.Wrap(err, "validate")
+					}
+				} else {
+					return req, close, errors.Wrap(err, "query")
+				}
+			}
+			{
+				cfg := uri.QueryParameterDecodingConfig{
+					Name:    "referenceURL",
+					Style:   uri.QueryStyleForm,
+					Explode: true,
+				}
+				if err := q.HasParam(cfg); err == nil {
+					if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+						var optFormDotReferenceURLVal string
+						if err := func() error {
+							val, err := d.DecodeValue()
+							if err != nil {
+								return err
+							}
+
+							c, err := conv.ToString(val)
+							if err != nil {
+								return err
+							}
+
+							optFormDotReferenceURLVal = c
+							return nil
+						}(); err != nil {
+							return err
+						}
+						optForm.ReferenceURL.SetTo(optFormDotReferenceURLVal)
+						return nil
+					}); err != nil {
+						return req, close, errors.Wrap(err, "decode \"referenceURL\"")
+					}
+				}
+			}
+			{
+				if err := func() error {
+					files, ok := r.MultipartForm.File["picture"]
+					if !ok || len(files) < 1 {
+						return nil
+					}
+					fh := files[0]
+
+					f, err := fh.Open()
+					if err != nil {
+						return errors.Wrap(err, "open")
+					}
+					closers = append(closers, f.Close)
+					optForm.Picture.SetTo(ht.MultipartFile{
+						Name:   fh.Filename,
+						File:   f,
+						Size:   fh.Size,
+						Header: fh.Header,
+					})
+					return nil
+				}(); err != nil {
+					return req, close, errors.Wrap(err, "decode \"picture\"")
+				}
+			}
+			request = OptPostOpinionPost2Req{
+				Value: optForm,
+				Set:   true,
+			}
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
 func (s *Server) decodePostTimeLineItemRequest(r *http.Request) (
 	req OptPostTimeLineItemReq,
 	close func() error,

--- a/internal/presentation/oas/oas_response_encoders_gen.go
+++ b/internal/presentation/oas/oas_response_encoders_gen.go
@@ -1339,6 +1339,52 @@ func encodePostOpinionPostResponse(response PostOpinionPostRes, w http.ResponseW
 	}
 }
 
+func encodePostOpinionPost2Response(response PostOpinionPost2Res, w http.ResponseWriter, span trace.Span) error {
+	switch response := response.(type) {
+	case *PostOpinionPost2OK:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *PostOpinionPost2BadRequest:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *PostOpinionPost2InternalServerError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
 func encodePostTimeLineItemResponse(response PostTimeLineItemRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
 	case *PostTimeLineItemOK:

--- a/internal/presentation/oas/oas_router_gen.go
+++ b/internal/presentation/oas/oas_router_gen.go
@@ -278,57 +278,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 
 				elem = origElem
-			case 'o': // Prefix: "opinions/"
+			case 'o': // Prefix: "opinions"
 				origElem := elem
-				if l := len("opinions/"); len(elem) >= l && elem[0:l] == "opinions/" {
+				if l := len("opinions"); len(elem) >= l && elem[0:l] == "opinions" {
 					elem = elem[l:]
 				} else {
 					break
 				}
 
 				if len(elem) == 0 {
-					break
-				}
-				switch elem[0] {
-				case 'h': // Prefix: "histories"
-					origElem := elem
-					if l := len("histories"); len(elem) >= l && elem[0:l] == "histories" {
-						elem = elem[l:]
-					} else {
-						break
-					}
-
-					if len(elem) == 0 {
-						// Leaf node.
-						switch r.Method {
-						case "GET":
-							s.handleOpinionsHistoryRequest([0]string{}, elemIsEscaped, w, r)
-						default:
-							s.notAllowed(w, r, "GET")
-						}
-
-						return
-					}
-
-					elem = origElem
-				}
-				// Param: "opinionID"
-				// Match until "/"
-				idx := strings.IndexByte(elem, '/')
-				if idx < 0 {
-					idx = len(elem)
-				}
-				args[0] = elem[:idx]
-				elem = elem[idx:]
-
-				if len(elem) == 0 {
 					switch r.Method {
-					case "GET":
-						s.handleGetOpinionDetail2Request([1]string{
-							args[0],
-						}, elemIsEscaped, w, r)
+					case "POST":
+						s.handlePostOpinionPost2Request([0]string{}, elemIsEscaped, w, r)
 					default:
-						s.notAllowed(w, r, "GET")
+						s.notAllowed(w, r, "POST")
 					}
 
 					return
@@ -346,9 +309,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						break
 					}
 					switch elem[0] {
-					case 'r': // Prefix: "replies"
+					case 'h': // Prefix: "histories"
 						origElem := elem
-						if l := len("replies"); len(elem) >= l && elem[0:l] == "replies" {
+						if l := len("histories"); len(elem) >= l && elem[0:l] == "histories" {
 							elem = elem[l:]
 						} else {
 							break
@@ -358,9 +321,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							// Leaf node.
 							switch r.Method {
 							case "GET":
-								s.handleOpinionComments2Request([1]string{
-									args[0],
-								}, elemIsEscaped, w, r)
+								s.handleOpinionsHistoryRequest([0]string{}, elemIsEscaped, w, r)
 							default:
 								s.notAllowed(w, r, "GET")
 							}
@@ -369,26 +330,87 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 
 						elem = origElem
-					case 'v': // Prefix: "votes"
+					}
+					// Param: "opinionID"
+					// Match until "/"
+					idx := strings.IndexByte(elem, '/')
+					if idx < 0 {
+						idx = len(elem)
+					}
+					args[0] = elem[:idx]
+					elem = elem[idx:]
+
+					if len(elem) == 0 {
+						switch r.Method {
+						case "GET":
+							s.handleGetOpinionDetail2Request([1]string{
+								args[0],
+							}, elemIsEscaped, w, r)
+						default:
+							s.notAllowed(w, r, "GET")
+						}
+
+						return
+					}
+					switch elem[0] {
+					case '/': // Prefix: "/"
 						origElem := elem
-						if l := len("votes"); len(elem) >= l && elem[0:l] == "votes" {
+						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
 							break
 						}
 
 						if len(elem) == 0 {
-							// Leaf node.
-							switch r.Method {
-							case "POST":
-								s.handleVote2Request([1]string{
-									args[0],
-								}, elemIsEscaped, w, r)
-							default:
-								s.notAllowed(w, r, "POST")
+							break
+						}
+						switch elem[0] {
+						case 'r': // Prefix: "replies"
+							origElem := elem
+							if l := len("replies"); len(elem) >= l && elem[0:l] == "replies" {
+								elem = elem[l:]
+							} else {
+								break
 							}
 
-							return
+							if len(elem) == 0 {
+								// Leaf node.
+								switch r.Method {
+								case "GET":
+									s.handleOpinionComments2Request([1]string{
+										args[0],
+									}, elemIsEscaped, w, r)
+								default:
+									s.notAllowed(w, r, "GET")
+								}
+
+								return
+							}
+
+							elem = origElem
+						case 'v': // Prefix: "votes"
+							origElem := elem
+							if l := len("votes"); len(elem) >= l && elem[0:l] == "votes" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch r.Method {
+								case "POST":
+									s.handleVote2Request([1]string{
+										args[0],
+									}, elemIsEscaped, w, r)
+								default:
+									s.notAllowed(w, r, "POST")
+								}
+
+								return
+							}
+
+							elem = origElem
 						}
 
 						elem = origElem
@@ -1263,62 +1285,23 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				}
 
 				elem = origElem
-			case 'o': // Prefix: "opinions/"
+			case 'o': // Prefix: "opinions"
 				origElem := elem
-				if l := len("opinions/"); len(elem) >= l && elem[0:l] == "opinions/" {
+				if l := len("opinions"); len(elem) >= l && elem[0:l] == "opinions" {
 					elem = elem[l:]
 				} else {
 					break
 				}
 
 				if len(elem) == 0 {
-					break
-				}
-				switch elem[0] {
-				case 'h': // Prefix: "histories"
-					origElem := elem
-					if l := len("histories"); len(elem) >= l && elem[0:l] == "histories" {
-						elem = elem[l:]
-					} else {
-						break
-					}
-
-					if len(elem) == 0 {
-						// Leaf node.
-						switch method {
-						case "GET":
-							r.name = "OpinionsHistory"
-							r.summary = "今までに投稿した異見"
-							r.operationID = "opinionsHistory"
-							r.pathPattern = "/opinions/histories"
-							r.args = args
-							r.count = 0
-							return r, true
-						default:
-							return
-						}
-					}
-
-					elem = origElem
-				}
-				// Param: "opinionID"
-				// Match until "/"
-				idx := strings.IndexByte(elem, '/')
-				if idx < 0 {
-					idx = len(elem)
-				}
-				args[0] = elem[:idx]
-				elem = elem[idx:]
-
-				if len(elem) == 0 {
 					switch method {
-					case "GET":
-						r.name = "GetOpinionDetail2"
-						r.summary = "意見詳細"
-						r.operationID = "getOpinionDetail2"
-						r.pathPattern = "/opinions/{opinionID}"
+					case "POST":
+						r.name = "PostOpinionPost2"
+						r.summary = "セッションに対して意見投稿 or 意見に対するリプライ"
+						r.operationID = "postOpinionPost2"
+						r.pathPattern = "/opinions"
 						r.args = args
-						r.count = 1
+						r.count = 0
 						return r, true
 					default:
 						return
@@ -1337,9 +1320,9 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						break
 					}
 					switch elem[0] {
-					case 'r': // Prefix: "replies"
+					case 'h': // Prefix: "histories"
 						origElem := elem
-						if l := len("replies"); len(elem) >= l && elem[0:l] == "replies" {
+						if l := len("histories"); len(elem) >= l && elem[0:l] == "histories" {
 							elem = elem[l:]
 						} else {
 							break
@@ -1349,12 +1332,12 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							// Leaf node.
 							switch method {
 							case "GET":
-								r.name = "OpinionComments2"
-								r.summary = "意見に対するリプライ意見一覧"
-								r.operationID = "opinionComments2"
-								r.pathPattern = "/opinions/{opinionID}/replies"
+								r.name = "OpinionsHistory"
+								r.summary = "今までに投稿した異見"
+								r.operationID = "opinionsHistory"
+								r.pathPattern = "/opinions/histories"
 								r.args = args
-								r.count = 1
+								r.count = 0
 								return r, true
 							default:
 								return
@@ -1362,28 +1345,93 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 
 						elem = origElem
-					case 'v': // Prefix: "votes"
+					}
+					// Param: "opinionID"
+					// Match until "/"
+					idx := strings.IndexByte(elem, '/')
+					if idx < 0 {
+						idx = len(elem)
+					}
+					args[0] = elem[:idx]
+					elem = elem[idx:]
+
+					if len(elem) == 0 {
+						switch method {
+						case "GET":
+							r.name = "GetOpinionDetail2"
+							r.summary = "意見詳細"
+							r.operationID = "getOpinionDetail2"
+							r.pathPattern = "/opinions/{opinionID}"
+							r.args = args
+							r.count = 1
+							return r, true
+						default:
+							return
+						}
+					}
+					switch elem[0] {
+					case '/': // Prefix: "/"
 						origElem := elem
-						if l := len("votes"); len(elem) >= l && elem[0:l] == "votes" {
+						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
 							break
 						}
 
 						if len(elem) == 0 {
-							// Leaf node.
-							switch method {
-							case "POST":
-								r.name = "Vote2"
-								r.summary = "意思表明API"
-								r.operationID = "vote2"
-								r.pathPattern = "/opinions/{opinionID}/votes"
-								r.args = args
-								r.count = 1
-								return r, true
-							default:
-								return
+							break
+						}
+						switch elem[0] {
+						case 'r': // Prefix: "replies"
+							origElem := elem
+							if l := len("replies"); len(elem) >= l && elem[0:l] == "replies" {
+								elem = elem[l:]
+							} else {
+								break
 							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch method {
+								case "GET":
+									r.name = "OpinionComments2"
+									r.summary = "意見に対するリプライ意見一覧"
+									r.operationID = "opinionComments2"
+									r.pathPattern = "/opinions/{opinionID}/replies"
+									r.args = args
+									r.count = 1
+									return r, true
+								default:
+									return
+								}
+							}
+
+							elem = origElem
+						case 'v': // Prefix: "votes"
+							origElem := elem
+							if l := len("votes"); len(elem) >= l && elem[0:l] == "votes" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch method {
+								case "POST":
+									r.name = "Vote2"
+									r.summary = "意思表明API"
+									r.operationID = "vote2"
+									r.pathPattern = "/opinions/{opinionID}/votes"
+									r.args = args
+									r.count = 1
+									return r, true
+								default:
+									return
+								}
+							}
+
+							elem = origElem
 						}
 
 						elem = origElem

--- a/internal/presentation/oas/oas_schemas_gen.go
+++ b/internal/presentation/oas/oas_schemas_gen.go
@@ -6715,6 +6715,52 @@ func (o OptPostImageReq) Or(d PostImageReq) PostImageReq {
 	return d
 }
 
+// NewOptPostOpinionPost2Req returns new OptPostOpinionPost2Req with value set to v.
+func NewOptPostOpinionPost2Req(v PostOpinionPost2Req) OptPostOpinionPost2Req {
+	return OptPostOpinionPost2Req{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptPostOpinionPost2Req is optional PostOpinionPost2Req.
+type OptPostOpinionPost2Req struct {
+	Value PostOpinionPost2Req
+	Set   bool
+}
+
+// IsSet returns true if OptPostOpinionPost2Req was set.
+func (o OptPostOpinionPost2Req) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptPostOpinionPost2Req) Reset() {
+	var v PostOpinionPost2Req
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptPostOpinionPost2Req) SetTo(v PostOpinionPost2Req) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptPostOpinionPost2Req) Get() (v PostOpinionPost2Req, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptPostOpinionPost2Req) Or(d PostOpinionPost2Req) PostOpinionPost2Req {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
 // NewOptPostOpinionPostReq returns new OptPostOpinionPostReq with value set to v.
 func NewOptPostOpinionPostReq(v PostOpinionPostReq) OptPostOpinionPostReq {
 	return OptPostOpinionPostReq{
@@ -7441,6 +7487,135 @@ func (s *PostImageReq) GetImage() ht.MultipartFile {
 // SetImage sets the value of Image.
 func (s *PostImageReq) SetImage(val ht.MultipartFile) {
 	s.Image = val
+}
+
+type PostOpinionPost2BadRequest struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// GetCode returns the value of Code.
+func (s *PostOpinionPost2BadRequest) GetCode() string {
+	return s.Code
+}
+
+// GetMessage returns the value of Message.
+func (s *PostOpinionPost2BadRequest) GetMessage() string {
+	return s.Message
+}
+
+// SetCode sets the value of Code.
+func (s *PostOpinionPost2BadRequest) SetCode(val string) {
+	s.Code = val
+}
+
+// SetMessage sets the value of Message.
+func (s *PostOpinionPost2BadRequest) SetMessage(val string) {
+	s.Message = val
+}
+
+func (*PostOpinionPost2BadRequest) postOpinionPost2Res() {}
+
+type PostOpinionPost2InternalServerError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// GetCode returns the value of Code.
+func (s *PostOpinionPost2InternalServerError) GetCode() string {
+	return s.Code
+}
+
+// GetMessage returns the value of Message.
+func (s *PostOpinionPost2InternalServerError) GetMessage() string {
+	return s.Message
+}
+
+// SetCode sets the value of Code.
+func (s *PostOpinionPost2InternalServerError) SetCode(val string) {
+	s.Code = val
+}
+
+// SetMessage sets the value of Message.
+func (s *PostOpinionPost2InternalServerError) SetMessage(val string) {
+	s.Message = val
+}
+
+func (*PostOpinionPost2InternalServerError) postOpinionPost2Res() {}
+
+type PostOpinionPost2OK struct{}
+
+func (*PostOpinionPost2OK) postOpinionPost2Res() {}
+
+type PostOpinionPost2Req struct {
+	TalkSessionID OptNilString `json:"talkSessionID"`
+	// これがある場合はリプライとみなす。これがない場合はTalkSessionIDが必須。.
+	ParentOpinionID OptNilString `json:"parentOpinionID"`
+	Title           OptNilString `json:"title"`
+	OpinionContent  string       `json:"opinionContent"`
+	ReferenceURL    OptNilString `json:"referenceURL"`
+	// 参考画像。4MiBまで.
+	Picture OptMultipartFile `json:"picture"`
+}
+
+// GetTalkSessionID returns the value of TalkSessionID.
+func (s *PostOpinionPost2Req) GetTalkSessionID() OptNilString {
+	return s.TalkSessionID
+}
+
+// GetParentOpinionID returns the value of ParentOpinionID.
+func (s *PostOpinionPost2Req) GetParentOpinionID() OptNilString {
+	return s.ParentOpinionID
+}
+
+// GetTitle returns the value of Title.
+func (s *PostOpinionPost2Req) GetTitle() OptNilString {
+	return s.Title
+}
+
+// GetOpinionContent returns the value of OpinionContent.
+func (s *PostOpinionPost2Req) GetOpinionContent() string {
+	return s.OpinionContent
+}
+
+// GetReferenceURL returns the value of ReferenceURL.
+func (s *PostOpinionPost2Req) GetReferenceURL() OptNilString {
+	return s.ReferenceURL
+}
+
+// GetPicture returns the value of Picture.
+func (s *PostOpinionPost2Req) GetPicture() OptMultipartFile {
+	return s.Picture
+}
+
+// SetTalkSessionID sets the value of TalkSessionID.
+func (s *PostOpinionPost2Req) SetTalkSessionID(val OptNilString) {
+	s.TalkSessionID = val
+}
+
+// SetParentOpinionID sets the value of ParentOpinionID.
+func (s *PostOpinionPost2Req) SetParentOpinionID(val OptNilString) {
+	s.ParentOpinionID = val
+}
+
+// SetTitle sets the value of Title.
+func (s *PostOpinionPost2Req) SetTitle(val OptNilString) {
+	s.Title = val
+}
+
+// SetOpinionContent sets the value of OpinionContent.
+func (s *PostOpinionPost2Req) SetOpinionContent(val string) {
+	s.OpinionContent = val
+}
+
+// SetReferenceURL sets the value of ReferenceURL.
+func (s *PostOpinionPost2Req) SetReferenceURL(val OptNilString) {
+	s.ReferenceURL = val
+}
+
+// SetPicture sets the value of Picture.
+func (s *PostOpinionPost2Req) SetPicture(val OptMultipartFile) {
+	s.Picture = val
 }
 
 type PostOpinionPostBadRequest struct {

--- a/internal/presentation/oas/oas_server_gen.go
+++ b/internal/presentation/oas/oas_server_gen.go
@@ -123,6 +123,13 @@ type OpinionHandler interface {
 	//
 	// POST /talksessions/{talkSessionID}/opinions
 	PostOpinionPost(ctx context.Context, req OptPostOpinionPostReq, params PostOpinionPostParams) (PostOpinionPostRes, error)
+	// PostOpinionPost2 implements postOpinionPost2 operation.
+	//
+	// ParentOpinionIDがなければルートの意見として投稿される
+	// parentOpinionIDがない場合はtalkSessionIDが必須.
+	//
+	// POST /opinions
+	PostOpinionPost2(ctx context.Context, req OptPostOpinionPost2Req) (PostOpinionPost2Res, error)
 	// SwipeOpinions implements swipe_opinions operation.
 	//
 	// セッションの中からまだ投票していない意見をランダムに取得する.

--- a/internal/presentation/oas/oas_unimplemented_gen.go
+++ b/internal/presentation/oas/oas_unimplemented_gen.go
@@ -280,6 +280,16 @@ func (UnimplementedHandler) PostOpinionPost(ctx context.Context, req OptPostOpin
 	return r, ht.ErrNotImplemented
 }
 
+// PostOpinionPost2 implements postOpinionPost2 operation.
+//
+// ParentOpinionIDがなければルートの意見として投稿される
+// parentOpinionIDがない場合はtalkSessionIDが必須.
+//
+// POST /opinions
+func (UnimplementedHandler) PostOpinionPost2(ctx context.Context, req OptPostOpinionPost2Req) (r PostOpinionPost2Res, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // PostTimeLineItem implements postTimeLineItem operation.
 //
 // タイムラインアイテム追加.

--- a/internal/presentation/oas/oas_validators_gen.go
+++ b/internal/presentation/oas/oas_validators_gen.go
@@ -2389,6 +2389,37 @@ func (s *PostConclusionReq) Validate() error {
 	return nil
 }
 
+func (s *PostOpinionPost2Req) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := (validate.String{
+			MinLength:    0,
+			MinLengthSet: false,
+			MaxLength:    140,
+			MaxLengthSet: true,
+			Email:        false,
+			Hostname:     false,
+			Regex:        nil,
+		}).Validate(string(s.OpinionContent)); err != nil {
+			return errors.Wrap(err, "string")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "opinionContent",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *PostOpinionPostReq) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -386,6 +386,106 @@ paths:
       security:
         - SessionId: []
       x-ogen-operation-group: Vote
+  /opinions:
+    post:
+      summary: セッションに対して意見投稿 or 意見に対するリプライ
+      deprecated: false
+      description: |-
+        parentOpinionIDがなければルートの意見として投稿される
+        parentOpinionIDがない場合はtalkSessionIDが必須
+      operationId: postOpinionPost2
+      tags:
+        - opinion
+      parameters: []
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                talkSessionID:
+                  type: string
+                  example: ''
+                  nullable: true
+                parentOpinionID:
+                  type: string
+                  description: これがある場合はリプライとみなす。これがない場合はTalkSessionIDが必須。
+                  example: ''
+                  nullable: true
+                title:
+                  type: string
+                  example: ''
+                  nullable: true
+                opinionContent:
+                  type: string
+                  maxLength: 140
+                  example: ''
+                referenceURL:
+                  type: string
+                  format: url
+                  example: ''
+                  nullable: true
+                picture:
+                  type: string
+                  format: binary
+                  description: 参考画像。4MiBまで
+                  example: ''
+              required:
+                - opinionContent
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+          headers: {}
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - code
+                  - message
+              examples:
+                '1':
+                  summary: internal
+                  value:
+                    code: GENERAL-000
+                    message: INTERNAL SERVER ERROR.
+          headers: {}
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - code
+                  - message
+              examples:
+                '1':
+                  summary: internal
+                  value:
+                    code: GENERAL-000
+                    message: INTERNAL SERVER ERROR.
+          headers: {}
+      security:
+        - SessionId: []
+      x-ogen-operation-group: Opinion
   /talksessions/{talkSessionID}/opinions/{opinionID}/votes:
     post:
       summary: 意思表明API


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 新たな意見投稿エンドポイントを導入し、ファイルアップロード対応と意見内容の入力検証（最大140文字）を実現しました。
  - ルート意見投稿が可能となり、セッション認証とエラーチェックが強化されました。

- **リファクタ**
  - 投稿ルートの整理により、処理が一元化され、全体の操作性と安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->