### PR TITLE
セッション作成者は制限に引っかからないように

### DIFF
--- a/internal/domain/service/talksession_access_control.go
+++ b/internal/domain/service/talksession_access_control.go
@@ -53,6 +53,11 @@ func (t *talkSessionAccessControl) CanUserJoin(ctx context.Context, talkSessionI
 		return false, messages.TalkSessionNotFound
 	}
 
+	// セッション作成者なら参加可能
+	if userID != nil && talkSession.OwnerUserID() == *userID {
+		return true, nil
+	}
+
 	// userの存在確認
 	var user *user.User
 	if userID != nil {

--- a/internal/presentation/handler/opinion_handler.go
+++ b/internal/presentation/handler/opinion_handler.go
@@ -491,7 +491,6 @@ func (o *opinionHandler) PostOpinionPost(ctx context.Context, req oas.OptPostOpi
 
 	if err = o.submitOpinionCommand.Execute(ctx, opinion_command.SubmitOpinionInput{
 		TalkSessionID:   &talkSessionID,
-		OwnerID:         userID,
 		UserID:          userID,
 		ParentOpinionID: parentOpinionID,
 		Title:           utils.ToPtrIfNotNullValue(!req.Value.Title.IsSet(), value.Title.Value),
@@ -553,7 +552,6 @@ func (o *opinionHandler) PostOpinionPost2(ctx context.Context, req oas.OptPostOp
 
 	if err = o.submitOpinionCommand.Execute(ctx, opinion_command.SubmitOpinionInput{
 		TalkSessionID:   talkSessionID,
-		OwnerID:         userID,
 		UserID:          userID,
 		ParentOpinionID: parentOpinionID,
 		Title:           utils.ToPtrIfNotNullValue(!req.Value.Title.IsSet(), value.Title.Value),

--- a/internal/usecase/command/opinion_command/submit_opinion.go
+++ b/internal/usecase/command/opinion_command/submit_opinion.go
@@ -30,7 +30,6 @@ type (
 		TalkSessionID *shared.UUID[talksession.TalkSession]
 		// ParentOpinionID 親意見IDがない場合はTalkSessionIDが必須
 		ParentOpinionID *shared.UUID[opinion.Opinion]
-		OwnerID         shared.UUID[user.User]
 		UserID          shared.UUID[user.User]
 		Title           *string
 		Content         string
@@ -100,7 +99,7 @@ func (h *submitOpinionHandler) Execute(ctx context.Context, input SubmitOpinionI
 		opinion, err := opinion.NewOpinion(
 			shared.NewUUID[opinion.Opinion](),
 			talkSessionID,
-			input.OwnerID,
+			input.UserID,
 			input.ParentOpinionID,
 			input.Title,
 			input.Content,
@@ -140,7 +139,7 @@ func (h *submitOpinionHandler) Execute(ctx context.Context, input SubmitOpinionI
 			if err := h.ImageRepository.Create(ctx, image.NewUserImage(
 				ctx,
 				shared.NewUUID[image.UserImage](),
-				input.OwnerID,
+				input.UserID,
 				*imageMeta,
 				*url,
 			)); err != nil {
@@ -161,7 +160,7 @@ func (h *submitOpinionHandler) Execute(ctx context.Context, input SubmitOpinionI
 			shared.NewUUID[vote.Vote](),
 			opinion.OpinionID(),
 			talkSessionID,
-			input.OwnerID,
+			input.UserID,
 			vote.Agree,
 			clock.Now(ctx),
 		)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - トークセッションのアクセスルールが改善され、セッションの所有者は自分のセッションに直接参加できるようになりました。

- **リファクタリング**
  - 意見投稿のプロセスが簡略化され、ユーザー識別の方法が統一されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->