### PR TITLE
🚑 制限のバリデーションエラーをよりわかりやすく

### DIFF
--- a/internal/domain/model/talksession/restriction.go
+++ b/internal/domain/model/talksession/restriction.go
@@ -2,6 +2,7 @@ package talksession
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/neko-dream/server/internal/domain/messages"
@@ -74,9 +75,12 @@ func (k *RestrictionAttributeKey) RestrictionAttribute() RestrictionAttribute {
 	return RestrictionAttributeKeyMap[*k]
 }
 
-func (k *RestrictionAttributeKey) IsValid() bool {
-	_, ok := RestrictionAttributeKeyMap[*k]
-	return ok
+func (k *RestrictionAttributeKey) IsValid() error {
+	attr, ok := RestrictionAttributeKeyMap[*k]
+	if !ok {
+		return errors.New(attr.Description + "が不正な値です")
+	}
+	return nil
 }
 
 var (

--- a/internal/domain/model/talksession/talk_session.go
+++ b/internal/domain/model/talksession/talk_session.go
@@ -2,6 +2,7 @@ package talksession
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/neko-dream/server/internal/domain/model/clock"
@@ -148,13 +149,20 @@ func (t *TalkSession) UpdateRestrictions(ctx context.Context, restrictions []str
 	_ = ctx
 
 	var attrs []*RestrictionAttribute
+	var errs error
 	for _, restriction := range restrictions {
 		attribute := RestrictionAttributeKey(restriction)
-		if !attribute.IsValid() {
-			return &ErrInvalidRestrictionAttribute
+		if err := attribute.IsValid(); err != nil{
+			errs = errors.Join(errs, err)
+			continue
 		}
 
 		attrs = append(attrs, lo.ToPtr(attribute.RestrictionAttribute()))
+	}
+	if errs != nil {
+		err := &ErrInvalidRestrictionAttribute
+		err.Message = errs.Error()
+		return err
 	}
 
 	t.restrictions = attrs


### PR DESCRIPTION
<!--
GitHub Copilot Reviewerへの指示: コードレビューしコメントする際は**必ず日本語**で行ってください。英語は絶対に使用しないでください。
-->

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo] (in my opinion)
[nits](nitpick)
[ask]
[fyi]
-->

<!--
データフロー図の生成指示:
このPRで変更されたコードのデータフローやプロセスフローをMermaid記法で図示してください。
以下のような図を生成してください：
1. コンポーネント間のデータの流れ
2. 処理の順序や条件分岐
3. 変更によって影響を受ける部分の関係性

例：
  ```
  graph TD
    A[入力データ] --&gt; B{処理モジュール}
    B --&gt; |条件1| C[出力1]
    B --&gt; |条件2| D[出力2]
    D --&gt; E[後続処理]
  ```
-->
<!-- for GitHub Copilot review rule -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 制限属性の検証時、複数の無効な属性がある場合にすべてのエラーメッセージをまとめて表示するよう改善されました。
  - 無効な制限属性が検出された際、より詳細なエラーメッセージが提供されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->