### PR TITLE
🚑 閲覧制限なくても同意必要にする

### DIFF
--- a/internal/domain/model/talksession/talksession_consent/service.go
+++ b/internal/domain/model/talksession/talksession_consent/service.go
@@ -71,7 +71,7 @@ func (s *talkSessionConsentService) HasConsented(
 	defer span.End()
 
 	// トークセッションが存在するか確認
-	talkSession, err := s.talkSessionRep.FindByID(ctx, talkSessionID)
+	_, err := s.talkSessionRep.FindByID(ctx, talkSessionID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, messages.TalkSessionNotFound
@@ -80,10 +80,6 @@ func (s *talkSessionConsentService) HasConsented(
 		return false, messages.InternalServerError
 	}
 
-	// restrictionsがない場合は常にtrueを返す
-	if talkSession.Restrictions() == nil || len(talkSession.Restrictions()) == 0 {
-		return true, nil
-	}
 	consents, err := s.talkSessionConsentRepository.FindByTalkSessionIDAndUserID(ctx, talkSessionID, userID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/domain/service/talksession_access_control.go
+++ b/internal/domain/service/talksession_access_control.go
@@ -72,11 +72,6 @@ func (t *talkSessionAccessControl) CanUserJoin(ctx context.Context, talkSessionI
 		}
 	}
 
-	// 参加制限がない場合は参加可能
-	if len(talkSession.Restrictions()) == 0 {
-		return true, nil
-	}
-
 	// 参加制限がある場合は、ユーザーが参加可能かを判定し、もし参加制限に引っかかる場合はエラーを返す
 	var restrictions []talksession.RestrictionAttribute
 	for _, restriction := range talkSession.Restrictions() {

--- a/internal/usecase/command/organization_command/invite_user.go
+++ b/internal/usecase/command/organization_command/invite_user.go
@@ -57,6 +57,9 @@ func (i *inviteOrganizationForUserInteractor) Execute(ctx context.Context, input
 		utils.HandleError(ctx, err, "userRepository.FindByDisplayID")
 		return nil, messages.UserNotFound
 	}
+	if user == nil {
+		return nil, messages.UserNotFound
+	}
 
 	// ログインユーザーが組織の管理者であることを確認
 	orgUser, err := i.organizationUserRepository.FindByOrganizationIDAndUserID(ctx, input.OrganizationID, input.UserID)


### PR DESCRIPTION
<!--
GitHub Copilot Reviewerへの指示: コードレビューしコメントする際は**必ず日本語**で行ってください。英語は絶対に使用しないでください。
-->

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo] (in my opinion)
[nits](nitpick)
[ask]
[fyi]
-->

<!--
データフロー図の生成指示:
このPRで変更されたコードのデータフローやプロセスフローをMermaid記法で図示してください。
以下のような図を生成してください：
1. コンポーネント間のデータの流れ
2. 処理の順序や条件分岐
3. 変更によって影響を受ける部分の関係性

例：
  ```
  graph TD
    A[入力データ] --&gt; B{処理モジュール}
    B --&gt; |条件1| C[出力1]
    B --&gt; |条件2| D[出力2]
    D --&gt; E[後続処理]
  ```
-->
<!-- for GitHub Copilot review rule -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 参加制限がないトークセッションでも、参加可否の判定処理が常に実行されるようになりました。
  - 参加制限の有無に関わらず、ユーザーの同意確認が正しく行われるようになりました。
  - ユーザー招待時に、存在しないユーザーIDの場合は適切にエラーが返されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->