### PR TITLE
制限に対して依存する制限を指定できるように

### DIFF
--- a/api/target/apidog.openapi.yaml
+++ b/api/target/apidog.openapi.yaml
@@ -6886,6 +6886,13 @@
           },
           "description": {
             "type": "string"
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "依存しているrestriction"
           }
         },
         "required": [

--- a/internal/domain/model/talksession/restriction.go
+++ b/internal/domain/model/talksession/restriction.go
@@ -13,6 +13,7 @@ type RestrictionAttribute struct {
 	Key         RestrictionAttributeKey
 	Description string
 	Order       int
+	DependsOn   []RestrictionAttributeKey
 	// IsSatisfied ユーザーが条件を満たしているかを判定する
 	IsSatisfied func(user user.User) bool
 }
@@ -57,7 +58,9 @@ var (
 					return false
 				}
 				return user.Demographics().City() != nil
-			}},
+			},
+			DependsOn: []RestrictionAttributeKey{DemographicsPrefecture},
+		},
 		DemographicsPrefecture: {
 			Key:         DemographicsPrefecture,
 			Description: "都道府県",

--- a/internal/presentation/handler/talk_session_handler.go
+++ b/internal/presentation/handler/talk_session_handler.go
@@ -726,6 +726,7 @@ func (t *talkSessionHandler) GetTalkSessionRestrictionKeys(ctx context.Context) 
 		keys = append(keys, oas.Restriction{
 			Key:         string(restriction.Key),
 			Description: restriction.Description,
+			DependsOn:   lo.Map(restriction.DependsOn, func(item talksession.RestrictionAttributeKey, _ int) string { return string(item) }),
 		})
 	}
 

--- a/internal/presentation/oas/oas_json_gen.go
+++ b/internal/presentation/oas/oas_json_gen.go
@@ -12735,6 +12735,16 @@ func (s *Restriction) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *Restriction) encodeFields(e *jx.Encoder) {
 	{
+		if s.DependsOn != nil {
+			e.FieldStart("dependsOn")
+			e.ArrStart()
+			for _, elem := range s.DependsOn {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
 		e.FieldStart("description")
 		e.Str(s.Description)
 	}
@@ -12744,9 +12754,10 @@ func (s *Restriction) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfRestriction = [2]string{
-	0: "description",
-	1: "key",
+var jsonFieldsNameOfRestriction = [3]string{
+	0: "dependsOn",
+	1: "description",
+	2: "key",
 }
 
 // Decode decodes Restriction from json.
@@ -12758,8 +12769,27 @@ func (s *Restriction) Decode(d *jx.Decoder) error {
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
+		case "dependsOn":
+			if err := func() error {
+				s.DependsOn = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.DependsOn = append(s.DependsOn, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"dependsOn\"")
+			}
 		case "description":
-			requiredBitSet[0] |= 1 << 0
+			requiredBitSet[0] |= 1 << 1
 			if err := func() error {
 				v, err := d.Str()
 				s.Description = string(v)
@@ -12771,7 +12801,7 @@ func (s *Restriction) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"description\"")
 			}
 		case "key":
-			requiredBitSet[0] |= 1 << 1
+			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
 				v, err := d.Str()
 				s.Key = string(v)
@@ -12792,7 +12822,7 @@ func (s *Restriction) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000011,
+		0b00000110,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/internal/presentation/oas/oas_schemas_gen.go
+++ b/internal/presentation/oas/oas_schemas_gen.go
@@ -7156,8 +7156,15 @@ func (s *ReportReason) SetReasonID(val int) {
 
 // Ref: #/components/schemas/restriction
 type Restriction struct {
-	Description string `json:"description"`
-	Key         string `json:"key"`
+	// 依存しているrestriction.
+	DependsOn   []string `json:"dependsOn"`
+	Description string   `json:"description"`
+	Key         string   `json:"key"`
+}
+
+// GetDependsOn returns the value of DependsOn.
+func (s *Restriction) GetDependsOn() []string {
+	return s.DependsOn
 }
 
 // GetDescription returns the value of Description.
@@ -7168,6 +7175,11 @@ func (s *Restriction) GetDescription() string {
 // GetKey returns the value of Key.
 func (s *Restriction) GetKey() string {
 	return s.Key
+}
+
+// SetDependsOn sets the value of DependsOn.
+func (s *Restriction) SetDependsOn(val []string) {
+	s.DependsOn = val
 }
 
 // SetDescription sets the value of Description.

--- a/static/oas/openapi.yaml
+++ b/static/oas/openapi.yaml
@@ -432,6 +432,11 @@ components:
             type: object
         restriction:
             properties:
+                dependsOn:
+                    description: 依存しているrestriction
+                    items:
+                        type: string
+                    type: array
                 description:
                     type: string
                 key:


### PR DESCRIPTION
<!--
GitHub Copilot Reviewerへの指示: コードレビューしコメントする際は**必ず日本語**で行ってください。英語は絶対に使用しないでください。
-->

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo] (in my opinion)
[nits](nitpick)
[ask]
[fyi]
-->

<!--
データフロー図の生成指示:
このPRで変更されたコードのデータフローやプロセスフローをMermaid記法で図示してください。
以下のような図を生成してください：
1. コンポーネント間のデータの流れ
2. 処理の順序や条件分岐
3. 変更によって影響を受ける部分の関係性

例：
  ```
  graph TD
    A[入力データ] --&gt; B{処理モジュール}
    B --&gt; |条件1| C[出力1]
    B --&gt; |条件2| D[出力2]
    D --&gt; E[後続処理]
  ```
-->
<!-- for GitHub Copilot review rule -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 制限属性に他の属性への依存関係（dependsOn）を追加しました。これにより、制限項目の依存関係がAPIレスポンスやドキュメントで確認できるようになりました。

- **ドキュメント**
  - APIスキーマに「dependsOn」フィールドが追加され、関連するgetter/setterも利用可能になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->