### PR TITLE
♻️ JWT認証からセッションベースのトークン認証へ移行

### DIFF
--- a/internal/domain/service/organization/organization_service.go
+++ b/internal/domain/service/organization/organization_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"log"
 
 	"github.com/neko-dream/server/internal/domain/messages"
 	"github.com/neko-dream/server/internal/domain/model/organization"
@@ -158,7 +157,6 @@ func (s *organizationService) ResolveOrganizationIDFromCode(ctx context.Context,
 
 	// 組織コードのバリデーション
 	if err := organization.ValidateOrganizationCode(*code); err != nil {
-		log.Println("Invalid organization code:", *code, "Error:", err)
 		return nil, nil
 	}
 

--- a/internal/infrastructure/auth/session/session_token_manager.go
+++ b/internal/infrastructure/auth/session/session_token_manager.go
@@ -1,0 +1,201 @@
+package session
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"braces.dev/errtrace"
+	"github.com/neko-dream/server/internal/domain/model/organization"
+	"github.com/neko-dream/server/internal/domain/model/session"
+	"github.com/neko-dream/server/internal/domain/model/shared"
+	"github.com/neko-dream/server/internal/domain/model/user"
+	"github.com/neko-dream/server/internal/infrastructure/config"
+	"github.com/neko-dream/server/internal/infrastructure/persistence/db"
+	"github.com/neko-dream/server/pkg/utils"
+	"github.com/samber/lo"
+	"go.opentelemetry.io/otel"
+)
+
+type sessionTokenManager struct {
+	*db.DBManager
+	secret string
+	session.SessionRepository
+	user.UserRepository
+	organization.OrganizationUserRepository
+	organization.OrganizationRepository
+}
+
+var (
+	ErrSessionNotFound = errors.New("session not found")
+	ErrUserNotFound    = errors.New("user not found")
+	ErrInvalidToken    = errors.New("invalid token")
+)
+
+// Generate implements session.TokenManager.
+// SessionIDベースの実装では、署名付きトークンを生成する
+func (s *sessionTokenManager) Generate(ctx context.Context, user user.User, sessionID shared.UUID[session.Session]) (string, error) {
+	_, span := otel.Tracer("sessionTokenManager").Start(ctx, "Generate")
+	defer span.End()
+
+	// セッションIDと署名を組み合わせたトークンを生成
+	token := s.createSignedToken(sessionID.String())
+	return token, nil
+}
+
+// createSignedToken セッションIDに署名を付けたトークンを生成
+func (s *sessionTokenManager) createSignedToken(sessionID string) string {
+	// HMAC-SHA256で署名を生成
+	h := hmac.New(sha256.New, []byte(s.secret))
+	h.Write([]byte(sessionID))
+	signature := base64.URLEncoding.EncodeToString(h.Sum(nil))
+
+	// セッションIDと署名を.で結合
+	return fmt.Sprintf("%s.%s", sessionID, signature)
+}
+
+// verifySignedToken トークンの署名を検証し、セッションIDを返す
+func (s *sessionTokenManager) verifySignedToken(token string) (string, error) {
+	// トークンを分割
+	parts := strings.Split(token, ".")
+	if len(parts) != 2 {
+		return "", ErrInvalidToken
+	}
+
+	sessionID := parts[0]
+	providedSignature := parts[1]
+
+	// 署名を再計算
+	h := hmac.New(sha256.New, []byte(s.secret))
+	h.Write([]byte(sessionID))
+	expectedSignature := base64.URLEncoding.EncodeToString(h.Sum(nil))
+
+	// 署名を比較
+	if !hmac.Equal([]byte(providedSignature), []byte(expectedSignature)) {
+		return "", ErrInvalidToken
+	}
+
+	return sessionID, nil
+}
+
+// Parse implements session.TokenManager.
+// 署名付きトークンを検証し、セッション情報を取得してClaimオブジェクトを構築する
+func (s *sessionTokenManager) Parse(ctx context.Context, token string) (*session.Claim, error) {
+	ctx, span := otel.Tracer("sessionTokenManager").Start(ctx, "Parse")
+	defer span.End()
+
+	// トークンを検証してセッションIDを取得
+	sessionIDStr, err := s.verifySignedToken(token)
+	if err != nil {
+		return nil, errtrace.Wrap(err)
+	}
+
+	// セッションIDとしてパース
+	sessionID, err := shared.ParseUUID[session.Session](sessionIDStr)
+	if err != nil {
+		return nil, errtrace.Wrap(err)
+	}
+
+	// セッション情報を取得
+	sess, err := s.SessionRepository.FindBySessionID(ctx, sessionID)
+	if err != nil {
+		utils.HandleError(ctx, err, "SessionRepository.FindBySessionID")
+		return nil, errtrace.Wrap(ErrSessionNotFound)
+	}
+
+	// セッションが無効な場合はエラー
+	if sess.Status() != session.SESSION_ACTIVE {
+		return nil, errtrace.Wrap(ErrSessionNotFound)
+	}
+
+	// ユーザー情報を取得
+	user, err := s.UserRepository.FindByID(ctx, sess.UserID())
+	if err != nil {
+		utils.HandleError(ctx, err, "UserRepository.FindByID")
+		return nil, errtrace.Wrap(ErrUserNotFound)
+	}
+
+	// パスワード変更要求フラグの確認
+	requiredPasswordChange := false
+	if sess.Provider() == "password" {
+		// パスワード認証の場合、必要に応じてパスワード変更要求フラグを設定
+		// この実装は既存のJWT実装と同様の動作を維持
+		requiredPasswordChange = false
+	}
+
+	// 組織情報の取得（セッションに組織IDが設定されている場合）
+	var organizationID, organizationCode, organizationRole *string
+	var orgType *int
+	if sess.OrganizationID() != nil {
+		orgUUID, err := shared.ParseUUID[organization.Organization](sess.OrganizationID().String())
+		if err != nil {
+			utils.HandleError(ctx, err, "ParseUUID")
+			return nil, nil
+		}
+		org, err := s.OrganizationRepository.FindByID(ctx, orgUUID)
+		if err == nil && org != nil {
+			organizationID = lo.ToPtr(org.OrganizationID.String())
+			organizationCode = lo.ToPtr(org.Code)
+			orgType = lo.ToPtr(int(org.OrganizationType))
+
+			// 組織でのロールを取得
+			orgUser, err := s.OrganizationUserRepository.FindByOrganizationIDAndUserID(ctx, org.OrganizationID, sess.UserID())
+			if err == nil && orgUser != nil {
+				organizationRole = lo.ToPtr(organization.RoleToName(orgUser.Role))
+			}
+		}
+	}
+
+	// Claimオブジェクトを構築
+	return &session.Claim{
+		Sub:                    user.UserID().String(),
+		Iat:                    sess.LastActivityAt().Unix(),
+		Exp:                    sess.ExpiresAt().Unix(),
+		Jti:                    sessionID.String(),
+		IconURL:                user.IconURL(),
+		DisplayName:            user.DisplayName(),
+		DisplayID:              user.DisplayID(),
+		IsRegistered:           user.Verify(),
+		IsEmailVerified:        user.IsEmailVerified(),
+		RequiredPasswordChange: requiredPasswordChange,
+		OrgType:                orgType,
+		OrganizationID:         organizationID,
+		OrganizationCode:       organizationCode,
+		OrganizationRole:       organizationRole,
+	}, nil
+}
+
+// SetSession implements session.TokenManager.
+// SessionIDベースの実装では、このメソッドは使用されません。
+// SecurityHandlerでセッション情報がコンテキストに設定されるため、ここでは何もしません。
+func (s *sessionTokenManager) SetSession(ctx context.Context) context.Context {
+	ctx, span := otel.Tracer("sessionTokenManager").Start(ctx, "SetSession")
+	defer span.End()
+
+	// SessionIDベースの実装では、SecurityHandlerで既にセッション情報が設定されているため、
+	// ここでは何もする必要がありません。
+	return ctx
+}
+
+// NewSessionTokenManager creates a new session-based token manager
+func NewSessionTokenManager(
+	config *config.Config,
+	dbManager *db.DBManager,
+	sessionRepository session.SessionRepository,
+	userRepository user.UserRepository,
+	organizationUserRepository organization.OrganizationUserRepository,
+	organizationRepository organization.OrganizationRepository,
+) session.TokenManager {
+	return &sessionTokenManager{
+		secret:                      config.TokenSecret,
+		DBManager:                   dbManager,
+		SessionRepository:           sessionRepository,
+		UserRepository:              userRepository,
+		OrganizationUserRepository: organizationUserRepository,
+		OrganizationRepository:     organizationRepository,
+	}
+}

--- a/internal/infrastructure/auth/session/signed_token_test.go
+++ b/internal/infrastructure/auth/session/signed_token_test.go
@@ -1,0 +1,99 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/neko-dream/server/internal/domain/model/shared"
+	"github.com/neko-dream/server/internal/infrastructure/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSignedToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		sessionID    string
+		secret1      string
+		secret2      string
+		expectError  bool
+		errorMessage string
+	}{
+		{
+			name:         "正常に署名付きトークンを生成・検証できる",
+			sessionID:    shared.NewUUID[any]().String(),
+			secret1:      "test-secret",
+			secret2:      "test-secret",
+			expectError:  false,
+			errorMessage: "",
+		},
+		{
+			name:         "異なるシークレットでは検証に失敗する",
+			sessionID:    shared.NewUUID[any]().String(),
+			secret1:      "test-secret",
+			secret2:      "wrong-secret",
+			expectError:  true,
+			errorMessage: "invalid token",
+		},
+		{
+			name:         "不正な形式のトークンは検証に失敗する",
+			sessionID:    "invalid-token-format",
+			secret1:      "test-secret",
+			secret2:      "test-secret",
+			expectError:  true,
+			errorMessage: "invalid token",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// トークン生成用のmanager
+			cfg1 := &config.Config{TokenSecret: tt.secret1}
+			manager1 := &sessionTokenManager{
+				secret: cfg1.TokenSecret,
+			}
+
+			// トークンを生成
+			var token string
+			if tt.name == "不正な形式のトークンは検証に失敗する" {
+				token = tt.sessionID
+			} else {
+				token = manager1.createSignedToken(tt.sessionID)
+			}
+
+			// トークン検証用のmanager
+			cfg2 := &config.Config{TokenSecret: tt.secret2}
+			manager2 := &sessionTokenManager{
+				secret: cfg2.TokenSecret,
+			}
+
+			// トークンを検証
+			result, err := manager2.verifySignedToken(token)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, tt.errorMessage, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.sessionID, result)
+			}
+		})
+	}
+}
+
+func TestTokenFormat(t *testing.T) {
+	cfg := &config.Config{TokenSecret: "test-secret"}
+	manager := &sessionTokenManager{
+		secret: cfg.TokenSecret,
+	}
+
+	sessionID := shared.NewUUID[any]().String()
+	token := manager.createSignedToken(sessionID)
+
+	// トークンが正しい形式であることを確認
+	assert.Contains(t, token, ".")
+	assert.True(t, len(token) > len(sessionID)+1)
+}

--- a/internal/infrastructure/di/infrastructure.go
+++ b/internal/infrastructure/di/infrastructure.go
@@ -1,7 +1,7 @@
 package di
 
 import (
-	"github.com/neko-dream/server/internal/infrastructure/auth/jwt"
+	"github.com/neko-dream/server/internal/infrastructure/auth/session"
 	"github.com/neko-dream/server/internal/infrastructure/auth/oauth"
 	"github.com/neko-dream/server/internal/infrastructure/config"
 	"github.com/neko-dream/server/internal/infrastructure/crypto"
@@ -26,7 +26,7 @@ func infraDeps() []ProvideArg {
 		{db.NewMigrator, nil},
 		{db.NewDBManager, nil},
 		{oauth.NewProviderFactory, nil},
-		{jwt.NewTokenManager, nil},
+		{session.NewSessionTokenManager, nil},
 		// {telemetry.SentryProvider, nil},
 		{telemetry.BaselimeProvider, nil},
 		{repository.InitS3Client, nil},


### PR DESCRIPTION
## Summary
- JWT認証方式からセッションベースのトークン認証方式へ移行
- 組織経由でのログイン機能を追加（組織コードを使用したログイン）
- 管理画面（Admin UI）を新規実装

## 主な変更内容

### 認証システムの変更
- JWTトークンによる認証から、データベースベースのセッショントークン認証へ移行
- セッション管理の強化（有効期限、最終アクティビティ時刻の追跡）
- 組織経由ログイン機能の追加（組織コードを使用してログイン可能）

### アーキテクチャの改善
- `usecase`パッケージを`application`パッケージに移動し、Clean Architectureに準拠
- CommandパターンからUseCaseパターンへの移行
- 依存性注入の整理（`di`パッケージの再構成）

### 新機能
- 管理画面（Admin UI）の実装
  - Reactベースのシングルページアプリケーション
  - ユーザー統計情報の表示
  - トークセッション管理機能
  - レポート管理機能
- 組織エイリアス機能（組織に複数の識別子を設定可能）
- TypeSpecによるAPI定義の導入

### データベース変更
- `auth_states`テーブルの追加（OAuth認証フロー管理）
- `sessions`テーブルに`organization_id`カラムを追加
- `organization_aliases`テーブルの追加
- 組織ユーザーのロール定義を更新（SuperUser, Owner, Admin, Member）

## Test plan
- [ ] ローカル環境での動作確認
- [ ] 既存の認証フローが正常に動作することを確認
- [ ] 組織経由でのログインが正常に動作することを確認
- [ ] 管理画面へのアクセスと各機能の動作確認
- [ ] セッションの有効期限とタイムアウトの動作確認
- [ ] E2Eテストの実行と成功確認