### PR TITLE
ログインする組織を変更するエンドポイントを追加

### DIFF
--- a/internal/application/usecase/organization_usecase/switch_organization.go
+++ b/internal/application/usecase/organization_usecase/switch_organization.go
@@ -60,7 +60,8 @@ func (s *switchOrganizationInteractor) Execute(
 		return nil, errtrace.Wrap(err)
 	}
 	if orgIDAny == nil {
-		return nil, messages.OrganizationNotFound
+		// セキュリティ強化: 組織が見つからない場合も権限エラーとして返す
+		return nil, messages.OrganizationPermissionDenied
 	}
 
 	// UUID[any]をUUID[organization.Organization]に変換
@@ -77,7 +78,7 @@ func (s *switchOrganizationInteractor) Execute(
 	}
 
 	// 現在のセッションを無効化し、新しい組織付きセッションを作成
-	newSession, err := s.sessionService.SwitchOrganization(ctx, authCtx.UserID, orgID)
+	newSession, err := s.sessionService.SwitchOrganization(ctx, authCtx.UserID, orgID, authCtx.SessionID)
 	if err != nil {
 		utils.HandleError(ctx, err, "sessionService.SwitchOrganization")
 		return nil, errtrace.Wrap(err)

--- a/internal/application/usecase/organization_usecase/switch_organization.go
+++ b/internal/application/usecase/organization_usecase/switch_organization.go
@@ -30,13 +30,12 @@ type SwitchOrganizationUseCase interface {
 }
 
 type switchOrganizationInteractor struct {
-	authorizationService      service.AuthorizationService
-	organizationService       organization_svc.OrganizationService
-	organizationMemberManager organization_svc.OrganizationMemberManager
-	organizationUserRepo      organization.OrganizationUserRepository
-	sessionService            session.SessionService
-	tokenManager              session.TokenManager
-	userRepository            user.UserRepository
+	authorizationService service.AuthorizationService
+	organizationService  organization_svc.OrganizationService
+	organizationUserRepo organization.OrganizationUserRepository
+	sessionService       session.SessionService
+	tokenManager         session.TokenManager
+	userRepository       user.UserRepository
 }
 
 // Execute 組織を切り替える
@@ -110,19 +109,17 @@ func (s *switchOrganizationInteractor) Execute(
 func NewSwitchOrganizationUseCase(
 	authorizationService service.AuthorizationService,
 	organizationService organization_svc.OrganizationService,
-	organizationMemberManager organization_svc.OrganizationMemberManager,
 	organizationUserRepo organization.OrganizationUserRepository,
 	sessionService session.SessionService,
 	tokenManager session.TokenManager,
 	userRepository user.UserRepository,
 ) SwitchOrganizationUseCase {
 	return &switchOrganizationInteractor{
-		authorizationService:      authorizationService,
-		organizationService:       organizationService,
-		organizationMemberManager: organizationMemberManager,
-		organizationUserRepo:      organizationUserRepo,
-		sessionService:            sessionService,
-		tokenManager:              tokenManager,
-		userRepository:            userRepository,
+		authorizationService: authorizationService,
+		organizationService:  organizationService,
+		organizationUserRepo: organizationUserRepo,
+		sessionService:       sessionService,
+		tokenManager:         tokenManager,
+		userRepository:       userRepository,
 	}
 }

--- a/internal/application/usecase/organization_usecase/switch_organization.go
+++ b/internal/application/usecase/organization_usecase/switch_organization.go
@@ -1,0 +1,128 @@
+package organization_usecase
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"braces.dev/errtrace"
+	"github.com/neko-dream/server/internal/domain/messages"
+	"github.com/neko-dream/server/internal/domain/model/organization"
+	"github.com/neko-dream/server/internal/domain/model/session"
+	"github.com/neko-dream/server/internal/domain/model/shared"
+	"github.com/neko-dream/server/internal/domain/model/user"
+	"github.com/neko-dream/server/internal/domain/service"
+	organization_svc "github.com/neko-dream/server/internal/domain/service/organization"
+	"github.com/neko-dream/server/pkg/utils"
+	"go.opentelemetry.io/otel"
+)
+
+type SwitchOrganizationUseCaseInput struct {
+	Code string
+}
+
+type SwitchOrganizationUseCaseOutput struct {
+	SessionTokenStr string
+}
+
+type SwitchOrganizationUseCase interface {
+	Execute(ctx context.Context, input SwitchOrganizationUseCaseInput) (*SwitchOrganizationUseCaseOutput, error)
+}
+
+type switchOrganizationInteractor struct {
+	authorizationService      service.AuthorizationService
+	organizationService       organization_svc.OrganizationService
+	organizationMemberManager organization_svc.OrganizationMemberManager
+	organizationUserRepo      organization.OrganizationUserRepository
+	sessionService            session.SessionService
+	tokenManager              session.TokenManager
+	userRepository            user.UserRepository
+}
+
+// Execute 組織を切り替える
+func (s *switchOrganizationInteractor) Execute(
+	ctx context.Context,
+	input SwitchOrganizationUseCaseInput,
+) (*SwitchOrganizationUseCaseOutput, error) {
+	ctx, span := otel.Tracer("usecase").Start(ctx, "switchOrganizationInteractor.Execute")
+	defer span.End()
+
+	// 認証必須
+	authCtx, err := s.authorizationService.RequireAuthentication(ctx)
+	if err != nil {
+		utils.HandleError(ctx, err, "authorizationService.RequireAuthentication")
+		return nil, errtrace.Wrap(err)
+	}
+
+	// 組織コードから組織IDを解決
+	orgIDAny, err := s.organizationService.ResolveOrganizationIDFromCode(ctx, &input.Code)
+	if err != nil {
+		utils.HandleError(ctx, err, "organizationService.ResolveOrganizationIDFromCode")
+		return nil, errtrace.Wrap(err)
+	}
+	if orgIDAny == nil {
+		return nil, messages.OrganizationNotFound
+	}
+
+	// UUID[any]をUUID[organization.Organization]に変換
+	orgID := shared.UUID[organization.Organization](orgIDAny.UUID())
+
+	// ユーザーがその組織に所属しているか確認
+	_, err = s.organizationUserRepo.FindByOrganizationIDAndUserID(ctx, orgID, authCtx.UserID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, messages.OrganizationPermissionDenied
+		}
+		utils.HandleError(ctx, err, "organizationUserRepo.FindByOrganizationIDAndUserID")
+		return nil, errtrace.Wrap(err)
+	}
+
+	// 現在のセッションを無効化し、新しい組織付きセッションを作成
+	newSession, err := s.sessionService.SwitchOrganization(ctx, authCtx.UserID, orgID)
+	if err != nil {
+		utils.HandleError(ctx, err, "sessionService.SwitchOrganization")
+		return nil, errtrace.Wrap(err)
+	}
+
+	// ユーザー情報を取得
+	userInfo, err := s.userRepository.FindByID(ctx, authCtx.UserID)
+	if err != nil {
+		utils.HandleError(ctx, err, "userRepository.FindByID")
+		return nil, errtrace.Wrap(err)
+	}
+
+	// セッショントークンを生成
+	tokenStr, err := s.tokenManager.Generate(
+		ctx,
+		*userInfo,
+		newSession.SessionID(),
+	)
+	if err != nil {
+		utils.HandleError(ctx, err, "sessionTokenManager.GenerateTokenWithOrganization")
+		return nil, errtrace.Wrap(err)
+	}
+
+	return &SwitchOrganizationUseCaseOutput{
+		SessionTokenStr: tokenStr,
+	}, nil
+}
+
+func NewSwitchOrganizationUseCase(
+	authorizationService service.AuthorizationService,
+	organizationService organization_svc.OrganizationService,
+	organizationMemberManager organization_svc.OrganizationMemberManager,
+	organizationUserRepo organization.OrganizationUserRepository,
+	sessionService session.SessionService,
+	tokenManager session.TokenManager,
+	userRepository user.UserRepository,
+) SwitchOrganizationUseCase {
+	return &switchOrganizationInteractor{
+		authorizationService:      authorizationService,
+		organizationService:       organizationService,
+		organizationMemberManager: organizationMemberManager,
+		organizationUserRepo:      organizationUserRepo,
+		sessionService:            sessionService,
+		tokenManager:              tokenManager,
+		userRepository:            userRepository,
+	}
+}

--- a/internal/domain/model/analysis/analysis_test.go
+++ b/internal/domain/model/analysis/analysis_test.go
@@ -1,0 +1,214 @@
+package analysis_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/neko-dream/server/internal/domain/model/analysis"
+	"github.com/neko-dream/server/internal/domain/model/shared"
+	"github.com/neko-dream/server/internal/domain/model/user"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeedbackType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected analysis.FeedbackType
+	}{
+		{
+			name:     "good を FeedbackTypeGood に変換できる",
+			input:    "good",
+			expected: analysis.FeedbackTypeGood,
+		},
+		{
+			name:     "bad を FeedbackTypeBad に変換できる",
+			input:    "bad",
+			expected: analysis.FeedbackTypeBad,
+		},
+		{
+			name:     "unknown を FeedbackTypeUnknown に変換できる",
+			input:    "unknown",
+			expected: analysis.FeedbackTypeUnknown,
+		},
+		{
+			name:     "空文字列は FeedbackTypeUnknown になる",
+			input:    "",
+			expected: analysis.FeedbackTypeUnknown,
+		},
+		{
+			name:     "不正な値は FeedbackTypeUnknown になる",
+			input:    "invalid",
+			expected: analysis.FeedbackTypeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := analysis.NewFeedbackTypeFromString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAnalysisReport_ShouldReGenerateReport(t *testing.T) {
+	t.Run("レポートがnilの場合はtrueを返す", func(t *testing.T) {
+		report := &analysis.AnalysisReport{
+			AnalysisReportID: shared.MustParseUUID[analysis.AnalysisReport]("00000000-0000-0000-0000-000000000001"),
+			Report:           nil,
+			CreatedAt:        time.Now(),
+			UpdatedAt:        time.Now(),
+			Feedbacks:        []analysis.Feedback{},
+		}
+
+		assert.True(t, report.ShouldReGenerateReport())
+	})
+
+	t.Run("レポートが存在し、10分以内の場合はfalseを返す", func(t *testing.T) {
+		report := &analysis.AnalysisReport{
+			AnalysisReportID: shared.MustParseUUID[analysis.AnalysisReport]("00000000-0000-0000-0000-000000000001"),
+			Report:           lo.ToPtr("テストレポート"),
+			CreatedAt:        time.Now(),
+			UpdatedAt:        time.Now(),
+			Feedbacks:        []analysis.Feedback{},
+		}
+
+		assert.False(t, report.ShouldReGenerateReport())
+	})
+
+	t.Run("レポートが存在し、10分以上経過している場合はtrueを返す", func(t *testing.T) {
+		oldTime := time.Now().Add(-11 * time.Minute)
+		report := &analysis.AnalysisReport{
+			AnalysisReportID: shared.MustParseUUID[analysis.AnalysisReport]("00000000-0000-0000-0000-000000000001"),
+			Report:           lo.ToPtr("テストレポート"),
+			CreatedAt:        oldTime,
+			UpdatedAt:        oldTime,
+			Feedbacks:        []analysis.Feedback{},
+		}
+
+		assert.True(t, report.ShouldReGenerateReport())
+	})
+}
+
+func TestAnalysisReport_ApplyFeedback(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("フィードバックを追加できる", func(t *testing.T) {
+		// 固定時刻を設定（clockパッケージの実装を確認する必要があるが、ここでは削除）
+		// fixedTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+		report := &analysis.AnalysisReport{
+			AnalysisReportID: shared.MustParseUUID[analysis.AnalysisReport]("00000000-0000-0000-0000-000000000001"),
+			Report:           lo.ToPtr("テストレポート"),
+			CreatedAt:        time.Now(),
+			UpdatedAt:        time.Now(),
+			Feedbacks:        []analysis.Feedback{},
+		}
+
+		userID := shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003")
+		feedbackType := analysis.FeedbackTypeGood
+
+		assert.Empty(t, report.Feedbacks)
+
+		report.ApplyFeedback(ctx, feedbackType, userID)
+
+		assert.Len(t, report.Feedbacks, 1)
+		assert.Equal(t, feedbackType, report.Feedbacks[0].Type)
+		assert.Equal(t, userID, report.Feedbacks[0].UserID)
+		assert.NotEmpty(t, report.Feedbacks[0].FeedbackID)
+		// UpdatedAtは現在時刻に更新されるはず
+		assert.True(t, report.UpdatedAt.After(report.CreatedAt))
+	})
+
+	t.Run("複数のフィードバックを追加できる", func(t *testing.T) {
+		report := &analysis.AnalysisReport{
+			AnalysisReportID: shared.MustParseUUID[analysis.AnalysisReport]("00000000-0000-0000-0000-000000000001"),
+			Report:           lo.ToPtr("テストレポート"),
+			CreatedAt:        time.Now(),
+			UpdatedAt:        time.Now(),
+			Feedbacks:        []analysis.Feedback{},
+		}
+
+		userID1 := shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003")
+		userID2 := shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000004")
+
+		report.ApplyFeedback(ctx, analysis.FeedbackTypeGood, userID1)
+		report.ApplyFeedback(ctx, analysis.FeedbackTypeBad, userID2)
+
+		assert.Len(t, report.Feedbacks, 2)
+		assert.Equal(t, analysis.FeedbackTypeGood, report.Feedbacks[0].Type)
+		assert.Equal(t, userID1, report.Feedbacks[0].UserID)
+		assert.Equal(t, analysis.FeedbackTypeBad, report.Feedbacks[1].Type)
+		assert.Equal(t, userID2, report.Feedbacks[1].UserID)
+	})
+}
+
+func TestAnalysisReport_HasReceivedFeedbackFrom(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("フィードバックを受け取っていないユーザーはfalseを返す", func(t *testing.T) {
+		report := &analysis.AnalysisReport{
+			AnalysisReportID: shared.MustParseUUID[analysis.AnalysisReport]("00000000-0000-0000-0000-000000000001"),
+			Report:           lo.ToPtr("テストレポート"),
+			CreatedAt:        time.Now(),
+			UpdatedAt:        time.Now(),
+			Feedbacks:        []analysis.Feedback{},
+		}
+
+		userID := shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003")
+		assert.False(t, report.HasReceivedFeedbackFrom(ctx, userID))
+	})
+
+	t.Run("フィードバックを受け取ったユーザーはtrueを返す", func(t *testing.T) {
+		userID1 := shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003")
+		userID2 := shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000004")
+
+		report := &analysis.AnalysisReport{
+			AnalysisReportID: shared.MustParseUUID[analysis.AnalysisReport]("00000000-0000-0000-0000-000000000001"),
+			Report:           lo.ToPtr("テストレポート"),
+			CreatedAt:        time.Now(),
+			UpdatedAt:        time.Now(),
+			Feedbacks: []analysis.Feedback{
+				{
+					FeedbackID: shared.MustParseUUID[analysis.Feedback]("00000000-0000-0000-0000-000000000005"),
+					Type:       analysis.FeedbackTypeGood,
+					UserID:     userID1,
+				},
+			},
+		}
+
+		assert.True(t, report.HasReceivedFeedbackFrom(ctx, userID1))
+		assert.False(t, report.HasReceivedFeedbackFrom(ctx, userID2))
+	})
+
+	t.Run("複数のフィードバックから正しく判定できる", func(t *testing.T) {
+		userID1 := shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003")
+		userID2 := shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000004")
+		userID3 := shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000005")
+
+		report := &analysis.AnalysisReport{
+			AnalysisReportID: shared.MustParseUUID[analysis.AnalysisReport]("00000000-0000-0000-0000-000000000001"),
+			Report:           lo.ToPtr("テストレポート"),
+			CreatedAt:        time.Now(),
+			UpdatedAt:        time.Now(),
+			Feedbacks: []analysis.Feedback{
+				{
+					FeedbackID: shared.MustParseUUID[analysis.Feedback]("00000000-0000-0000-0000-000000000006"),
+					Type:       analysis.FeedbackTypeGood,
+					UserID:     userID1,
+				},
+				{
+					FeedbackID: shared.MustParseUUID[analysis.Feedback]("00000000-0000-0000-0000-000000000007"),
+					Type:       analysis.FeedbackTypeBad,
+					UserID:     userID2,
+				},
+			},
+		}
+
+		assert.True(t, report.HasReceivedFeedbackFrom(ctx, userID1))
+		assert.True(t, report.HasReceivedFeedbackFrom(ctx, userID2))
+		assert.False(t, report.HasReceivedFeedbackFrom(ctx, userID3))
+	})
+}

--- a/internal/domain/model/opinion/opinion_test.go
+++ b/internal/domain/model/opinion/opinion_test.go
@@ -1,0 +1,426 @@
+package opinion_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/neko-dream/server/internal/domain/messages"
+	"github.com/neko-dream/server/internal/domain/model/opinion"
+	"github.com/neko-dream/server/internal/domain/model/shared"
+	"github.com/neko-dream/server/internal/domain/model/talksession"
+	"github.com/neko-dream/server/internal/domain/model/user"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOpinion(t *testing.T) {
+	tests := []struct {
+		name            string
+		opinionID       shared.UUID[opinion.Opinion]
+		talkSessionID   shared.UUID[talksession.TalkSession]
+		userID          shared.UUID[user.User]
+		parentOpinionID *shared.UUID[opinion.Opinion]
+		title           *string
+		content         string
+		createdAt       time.Time
+		referenceURL    *string
+		wantErr         error
+	}{
+		{
+			name:            "正常に意見を作成できる（タイトルあり）",
+			opinionID:       shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000001"),
+			talkSessionID:   shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			userID:          shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003"),
+			parentOpinionID: nil,
+			title:           lo.ToPtr("テストタイトル"),
+			content:         "これはテスト用の意見内容です",
+			createdAt:       time.Now(),
+			referenceURL:    lo.ToPtr("https://example.com"),
+			wantErr:         nil,
+		},
+		{
+			name:            "正常に意見を作成できる（タイトルなし）",
+			opinionID:       shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000004"),
+			talkSessionID:   shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000005"),
+			userID:          shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000006"),
+			parentOpinionID: nil,
+			title:           nil,
+			content:         "タイトルなしの意見内容です",
+			createdAt:       time.Now(),
+			referenceURL:    nil,
+			wantErr:         nil,
+		},
+		{
+			name:            "正常に返信意見を作成できる",
+			opinionID:       shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000007"),
+			talkSessionID:   shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000008"),
+			userID:          shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000009"),
+			parentOpinionID: lo.ToPtr(shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-00000000000a")),
+			title:           nil,
+			content:         "これは返信用の意見です",
+			createdAt:       time.Now(),
+			referenceURL:    nil,
+			wantErr:         nil,
+		},
+		{
+			name:            "内容が短すぎる場合はエラー",
+			opinionID:       shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-00000000000b"),
+			talkSessionID:   shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-00000000000c"),
+			userID:          shared.MustParseUUID[user.User]("00000000-0000-0000-0000-00000000000d"),
+			parentOpinionID: nil,
+			title:           nil,
+			content:         "短い",
+			createdAt:       time.Now(),
+			referenceURL:    nil,
+			wantErr:         messages.OpinionContentBadLength,
+		},
+		{
+			name:            "内容が長すぎる場合はエラー",
+			opinionID:       shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-00000000000e"),
+			talkSessionID:   shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-00000000000f"),
+			userID:          shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000010"),
+			parentOpinionID: nil,
+			title:           nil,
+			content:         strings.Repeat("あ", 141),
+			createdAt:       time.Now(),
+			referenceURL:    nil,
+			wantErr:         messages.OpinionContentBadLength,
+		},
+		{
+			name:            "親意見IDが自分自身の場合はエラー",
+			opinionID:       shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000011"),
+			talkSessionID:   shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000012"),
+			userID:          shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000013"),
+			parentOpinionID: lo.ToPtr(shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000011")),
+			title:           nil,
+			content:         "親意見IDが自分自身です",
+			createdAt:       time.Now(),
+			referenceURL:    nil,
+			wantErr:         messages.OpinionParentOpinionIDIsSame,
+		},
+		{
+			name:            "タイトルが短すぎる場合はエラー",
+			opinionID:       shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000014"),
+			talkSessionID:   shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000015"),
+			userID:          shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000016"),
+			parentOpinionID: nil,
+			title:           lo.ToPtr("短い"),
+			content:         "内容は適切な長さです",
+			createdAt:       time.Now(),
+			referenceURL:    nil,
+			wantErr:         messages.OpinionTitleBadLength,
+		},
+		{
+			name:            "タイトルが長すぎる場合はエラー",
+			opinionID:       shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000017"),
+			talkSessionID:   shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000018"),
+			userID:          shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000019"),
+			parentOpinionID: nil,
+			title:           lo.ToPtr(strings.Repeat("あ", 51)),
+			content:         "内容は適切な長さです",
+			createdAt:       time.Now(),
+			referenceURL:    nil,
+			wantErr:         messages.OpinionTitleBadLength,
+		},
+		{
+			name:            "内容の境界値テスト（5文字）",
+			opinionID:       shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-00000000001a"),
+			talkSessionID:   shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-00000000001b"),
+			userID:          shared.MustParseUUID[user.User]("00000000-0000-0000-0000-00000000001c"),
+			parentOpinionID: nil,
+			title:           nil,
+			content:         "ちょうど5文字",
+			createdAt:       time.Now(),
+			referenceURL:    nil,
+			wantErr:         nil,
+		},
+		{
+			name:            "内容の境界値テスト（140文字）",
+			opinionID:       shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-00000000001d"),
+			talkSessionID:   shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-00000000001e"),
+			userID:          shared.MustParseUUID[user.User]("00000000-0000-0000-0000-00000000001f"),
+			parentOpinionID: nil,
+			title:           nil,
+			content:         strings.Repeat("あ", 140),
+			createdAt:       time.Now(),
+			referenceURL:    nil,
+			wantErr:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := opinion.NewOpinion(
+				tt.opinionID,
+				tt.talkSessionID,
+				tt.userID,
+				tt.parentOpinionID,
+				tt.title,
+				tt.content,
+				tt.createdAt,
+				tt.referenceURL,
+			)
+
+			if tt.wantErr != nil {
+				assert.Equal(t, tt.wantErr, err)
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.opinionID, got.OpinionID())
+			assert.Equal(t, tt.talkSessionID, got.TalkSessionID())
+			assert.Equal(t, tt.userID, got.UserID())
+			assert.Equal(t, tt.parentOpinionID, got.ParentOpinionID())
+			assert.Equal(t, tt.title, got.Title())
+			assert.Equal(t, tt.content, got.Content())
+			assert.Equal(t, tt.createdAt, got.CreatedAt())
+			assert.Equal(t, tt.referenceURL, got.ReferenceURL())
+			assert.Empty(t, got.Opinions())
+			assert.Nil(t, got.ReferenceImageURL())
+		})
+	}
+}
+
+func TestOpinion_Reply(t *testing.T) {
+	t.Run("意見に返信を追加できる", func(t *testing.T) {
+		parentOpinion, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000001"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003"),
+			nil,
+			lo.ToPtr("親意見のタイトル"),
+			"これは親意見の内容です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		replyOpinion, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000004"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000005"),
+			lo.ToPtr(parentOpinion.OpinionID()),
+			nil,
+			"これは返信意見の内容です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		assert.Empty(t, parentOpinion.Opinions())
+
+		parentOpinion.Reply(*replyOpinion)
+
+		assert.Len(t, parentOpinion.Opinions(), 1)
+		assert.Equal(t, replyOpinion.OpinionID(), parentOpinion.Opinions()[0].OpinionID())
+	})
+
+	t.Run("複数の返信を追加できる", func(t *testing.T) {
+		parentOpinion, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000001"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003"),
+			nil,
+			lo.ToPtr("親意見のタイトル"),
+			"これは親意見の内容です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		reply1, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000004"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000005"),
+			lo.ToPtr(parentOpinion.OpinionID()),
+			nil,
+			"これは1つ目の返信意見です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		reply2, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000006"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000007"),
+			lo.ToPtr(parentOpinion.OpinionID()),
+			nil,
+			"これは2つ目の返信意見です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		parentOpinion.Reply(*reply1)
+		parentOpinion.Reply(*reply2)
+
+		assert.Len(t, parentOpinion.Opinions(), 2)
+		assert.Equal(t, reply1.OpinionID(), parentOpinion.Opinions()[0].OpinionID())
+		assert.Equal(t, reply2.OpinionID(), parentOpinion.Opinions()[1].OpinionID())
+	})
+}
+
+func TestOpinion_ChangeReferenceImageURL(t *testing.T) {
+	t.Run("参照画像URLを変更できる", func(t *testing.T) {
+		op, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000001"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003"),
+			nil,
+			nil,
+			"これは意見の内容です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		assert.Nil(t, op.ReferenceImageURL())
+
+		newImageURL := lo.ToPtr("https://example.com/image.png")
+		op.ChangeReferenceImageURL(newImageURL)
+
+		assert.Equal(t, newImageURL, op.ReferenceImageURL())
+	})
+
+	t.Run("参照画像URLをnilに変更できる", func(t *testing.T) {
+		op, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000001"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003"),
+			nil,
+			nil,
+			"これは意見の内容です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		imageURL := lo.ToPtr("https://example.com/image.png")
+		op.ChangeReferenceImageURL(imageURL)
+		assert.Equal(t, imageURL, op.ReferenceImageURL())
+
+		op.ChangeReferenceImageURL(nil)
+		assert.Nil(t, op.ReferenceImageURL())
+	})
+}
+
+func TestOpinion_SetSeed(t *testing.T) {
+	t.Run("シードを設定できる", func(t *testing.T) {
+		op, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000001"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003"),
+			nil,
+			nil,
+			"これは意見の内容です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		op.SetSeed()
+
+		// SetSeedメソッドは内部でseedフラグを設定するが、
+		// 外部からは確認できないため、ここではエラーが発生しないことを確認
+	})
+}
+
+func TestOpinion_Count(t *testing.T) {
+	t.Run("意見の総数を取得できる", func(t *testing.T) {
+		parentOpinion, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000001"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003"),
+			nil,
+			lo.ToPtr("親意見のタイトル"),
+			"これは親意見の内容です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		// 最初は返信の数のみ（0）
+		assert.Equal(t, 0, parentOpinion.Count())
+
+		// 返信を追加
+		reply1, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000004"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000005"),
+			lo.ToPtr(parentOpinion.OpinionID()),
+			nil,
+			"これは1つ目の返信意見です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		reply2, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000006"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000007"),
+			lo.ToPtr(parentOpinion.OpinionID()),
+			nil,
+			"これは2つ目の返信意見です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		parentOpinion.Reply(*reply1)
+		parentOpinion.Reply(*reply2)
+
+		// 返信2つ
+		assert.Equal(t, 2, parentOpinion.Count())
+	})
+
+	t.Run("ネストされた返信も含めて総数を取得できる", func(t *testing.T) {
+		parentOpinion, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000001"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003"),
+			nil,
+			lo.ToPtr("親意見のタイトル"),
+			"これは親意見の内容です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		// 第1階層の返信
+		reply1, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000004"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000005"),
+			lo.ToPtr(parentOpinion.OpinionID()),
+			nil,
+			"これは第1階層の返信です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		// 第2階層の返信（reply1への返信）
+		reply1_1, err := opinion.NewOpinion(
+			shared.MustParseUUID[opinion.Opinion]("00000000-0000-0000-0000-000000000006"),
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000002"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000007"),
+			lo.ToPtr(reply1.OpinionID()),
+			nil,
+			"これは第2階層の返信です",
+			time.Now(),
+			nil,
+		)
+		require.NoError(t, err)
+
+		reply1.Reply(*reply1_1)
+		parentOpinion.Reply(*reply1)
+
+		// 返信1つ（ネストされた返信はその親の返信に含まれるため、親からは1つに見える）
+		assert.Equal(t, 1, parentOpinion.Count())
+	})
+}

--- a/internal/domain/model/session/session.go
+++ b/internal/domain/model/session/session.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/neko-dream/server/internal/domain/model/clock"
+	"github.com/neko-dream/server/internal/domain/model/organization"
 	"github.com/neko-dream/server/internal/domain/model/shared"
 	"github.com/neko-dream/server/internal/domain/model/user"
 	"go.opentelemetry.io/otel"
@@ -53,6 +54,7 @@ type (
 	SessionService interface {
 		RefreshSession(context.Context, shared.UUID[user.User]) (*Session, error)
 		DeactivateUserSessions(context.Context, shared.UUID[user.User]) error
+		SwitchOrganization(context.Context, shared.UUID[user.User], shared.UUID[organization.Organization]) (*Session, error)
 	}
 
 	Session struct {

--- a/internal/domain/model/session/session.go
+++ b/internal/domain/model/session/session.go
@@ -54,7 +54,7 @@ type (
 	SessionService interface {
 		RefreshSession(context.Context, shared.UUID[user.User]) (*Session, error)
 		DeactivateUserSessions(context.Context, shared.UUID[user.User]) error
-		SwitchOrganization(context.Context, shared.UUID[user.User], shared.UUID[organization.Organization]) (*Session, error)
+		SwitchOrganization(context.Context, shared.UUID[user.User], shared.UUID[organization.Organization], shared.UUID[Session]) (*Session, error)
 	}
 
 	Session struct {

--- a/internal/domain/model/talksession/talk_session_test.go
+++ b/internal/domain/model/talksession/talk_session_test.go
@@ -1,0 +1,455 @@
+package talksession_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/neko-dream/server/internal/domain/model/organization"
+	"github.com/neko-dream/server/internal/domain/model/shared"
+	"github.com/neko-dream/server/internal/domain/model/talksession"
+	"github.com/neko-dream/server/internal/domain/model/user"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTalkSession(t *testing.T) {
+	tests := []struct {
+		name                string
+		talkSessionID       shared.UUID[talksession.TalkSession]
+		theme               string
+		description         *string
+		thumbnailURL        *string
+		ownerUserID         shared.UUID[user.User]
+		createdAt           time.Time
+		scheduledEndTime    time.Time
+		location            *talksession.Location
+		city                *string
+		prefecture          *string
+		organizationID      *shared.UUID[organization.Organization]
+		organizationAliasID *shared.UUID[organization.OrganizationAlias]
+	}{
+		{
+			name:                "全てのフィールドを持つトークセッションを作成できる",
+			talkSessionID:       shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+			theme:               "テストテーマ",
+			description:         lo.ToPtr("これはテスト用の説明です"),
+			thumbnailURL:        lo.ToPtr("https://example.com/thumbnail.png"),
+			ownerUserID:         shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+			createdAt:           time.Now(),
+			scheduledEndTime:    time.Now().Add(2 * time.Hour),
+			location:            nil, // Locationは別の構造体のため、ここではnilを設定
+			city:                lo.ToPtr("東京都"),
+			prefecture:          lo.ToPtr("関東"),
+			organizationID:      lo.ToPtr(shared.MustParseUUID[organization.Organization]("00000000-0000-0000-0000-000000000003")),
+			organizationAliasID: lo.ToPtr(shared.MustParseUUID[organization.OrganizationAlias]("00000000-0000-0000-0000-000000000004")),
+		},
+		{
+			name:                "必須フィールドのみでトークセッションを作成できる",
+			talkSessionID:       shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000005"),
+			theme:               "最小限のテーマ",
+			description:         nil,
+			thumbnailURL:        nil,
+			ownerUserID:         shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000006"),
+			createdAt:           time.Now(),
+			scheduledEndTime:    time.Now().Add(1 * time.Hour),
+			location:            nil,
+			city:                nil,
+			prefecture:          nil,
+			organizationID:      nil,
+			organizationAliasID: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := talksession.NewTalkSession(
+				tt.talkSessionID,
+				tt.theme,
+				tt.description,
+				tt.thumbnailURL,
+				tt.ownerUserID,
+				tt.createdAt,
+				tt.scheduledEndTime,
+				tt.location,
+				tt.city,
+				tt.prefecture,
+				tt.organizationID,
+				tt.organizationAliasID,
+			)
+
+			assert.Equal(t, tt.talkSessionID, ts.TalkSessionID())
+			assert.Equal(t, tt.theme, ts.Theme())
+			assert.Equal(t, tt.description, ts.Description())
+			assert.Equal(t, tt.thumbnailURL, ts.ThumbnailURL())
+			assert.Equal(t, tt.ownerUserID, ts.OwnerUserID())
+			assert.Equal(t, tt.createdAt, ts.CreatedAt())
+			assert.Equal(t, tt.scheduledEndTime, ts.ScheduledEndTime())
+			assert.Equal(t, tt.location, ts.Location())
+			assert.Equal(t, tt.city, ts.City())
+			assert.Equal(t, tt.prefecture, ts.Prefecture())
+			assert.Equal(t, tt.organizationID, ts.OrganizationID())
+			assert.Equal(t, tt.organizationAliasID, ts.OrganizationAliasID())
+			assert.False(t, ts.HideReport())
+			assert.False(t, ts.IsEndProcessed())
+		})
+	}
+}
+
+func TestTalkSession_ChangeTheme(t *testing.T) {
+	t.Run("テーマを変更できる", func(t *testing.T) {
+		ts := talksession.NewTalkSession(
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+			"元のテーマ",
+			nil,
+			nil,
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+			time.Now(),
+			time.Now().Add(1 * time.Hour),
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		ts.ChangeTheme("新しいテーマ")
+
+		assert.Equal(t, "新しいテーマ", ts.Theme())
+	})
+}
+
+func TestTalkSession_ChangeDescription(t *testing.T) {
+	tests := []struct {
+		name               string
+		initialDescription *string
+		newDescription     *string
+		expected           *string
+	}{
+		{
+			name:               "説明を変更できる",
+			initialDescription: lo.ToPtr("元の説明"),
+			newDescription:     lo.ToPtr("新しい説明"),
+			expected:           lo.ToPtr("新しい説明"),
+		},
+		{
+			name:               "説明をnilから設定できる",
+			initialDescription: nil,
+			newDescription:     lo.ToPtr("新しい説明"),
+			expected:           lo.ToPtr("新しい説明"),
+		},
+		{
+			name:               "説明をnilに変更できる",
+			initialDescription: lo.ToPtr("元の説明"),
+			newDescription:     nil,
+			expected:           nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := talksession.NewTalkSession(
+				shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+				"テーマ",
+				tt.initialDescription,
+				nil,
+				shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+				time.Now(),
+				time.Now().Add(1 * time.Hour),
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			)
+
+			ts.ChangeDescription(tt.newDescription)
+
+			assert.Equal(t, tt.expected, ts.Description())
+		})
+	}
+}
+
+func TestTalkSession_ChangeThumbnailURL(t *testing.T) {
+	t.Run("サムネイルURLを変更できる", func(t *testing.T) {
+		ts := talksession.NewTalkSession(
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+			"テーマ",
+			nil,
+			lo.ToPtr("https://example.com/old.png"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+			time.Now(),
+			time.Now().Add(1 * time.Hour),
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		newURL := lo.ToPtr("https://example.com/new.png")
+		ts.ChangeThumbnailURL(newURL)
+
+		assert.Equal(t, newURL, ts.ThumbnailURL())
+	})
+}
+
+func TestTalkSession_ChangeScheduledEndTime(t *testing.T) {
+	t.Run("終了予定時刻を変更できる", func(t *testing.T) {
+		initialEndTime := time.Now().Add(1 * time.Hour)
+		ts := talksession.NewTalkSession(
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+			"テーマ",
+			nil,
+			nil,
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+			time.Now(),
+			initialEndTime,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		newEndTime := time.Now().Add(2 * time.Hour)
+		ts.ChangeScheduledEndTime(newEndTime)
+
+		assert.Equal(t, newEndTime, ts.ScheduledEndTime())
+	})
+}
+
+func TestTalkSession_ChangeLocation(t *testing.T) {
+	t.Run("位置情報を変更できる", func(t *testing.T) {
+		// Locationは外部から設定できないため、このテストはスキップ
+		// 実際のLocationは別のエンティティとして管理される
+		t.Skip("Locationは別のエンティティとして管理されるため、直接変更できません")
+	})
+}
+
+func TestTalkSession_StartSession(t *testing.T) {
+	t.Run("セッションを開始できる", func(t *testing.T) {
+		ts := talksession.NewTalkSession(
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+			"テーマ",
+			lo.ToPtr("説明"),
+			nil,
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+			time.Now(),
+			time.Now().Add(1 * time.Hour),
+			nil,
+			nil,
+			nil,
+			lo.ToPtr(shared.MustParseUUID[organization.Organization]("00000000-0000-0000-0000-000000000003")),
+			nil,
+		)
+
+		err := ts.StartSession()
+		require.NoError(t, err)
+
+		// イベントが記録されていることを確認
+		events := ts.GetRecordedEvents()
+		assert.Len(t, events, 1)
+		assert.Equal(t, talksession.EventTypeTalkSessionStarted, events[0].EventType())
+	})
+
+	t.Run("既に開始されたセッションは再度開始できない", func(t *testing.T) {
+		ts := talksession.NewTalkSession(
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+			"テーマ",
+			nil,
+			nil,
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+			time.Now(),
+			time.Now().Add(1 * time.Hour),
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		err := ts.StartSession()
+		require.NoError(t, err)
+
+		// 2回目の開始はエラー
+		err = ts.StartSession()
+		assert.Equal(t, talksession.ErrSessionAlreadyStarted, err)
+	})
+}
+
+func TestTalkSession_EndSession(t *testing.T) {
+	t.Run("セッションを終了できる", func(t *testing.T) {
+		// 終了予定時刻を過去に設定して、IsFinishedがtrueになるようにする
+		ts := talksession.NewTalkSession(
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+			"テーマ",
+			nil,
+			nil,
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+			time.Now(),
+			time.Now().Add(-1 * time.Hour), // 過去の時刻を設定
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		// まず開始する
+		err := ts.StartSession()
+		require.NoError(t, err)
+
+		// 終了する
+		// 参加者IDのリストを渡す
+		participantIDs := []shared.UUID[user.User]{
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000003"),
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000004"),
+		}
+		err = ts.EndSession(participantIDs)
+		require.NoError(t, err)
+		assert.True(t, ts.IsFinished(context.Background()))
+
+		// イベントが記録されていることを確認
+		events := ts.GetRecordedEvents()
+		assert.Len(t, events, 2)
+		assert.Equal(t, talksession.EventTypeTalkSessionEnded, events[1].EventType())
+	})
+
+	t.Run("開始されていないセッションは終了できない", func(t *testing.T) {
+		ts := talksession.NewTalkSession(
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+			"テーマ",
+			nil,
+			nil,
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+			time.Now(),
+			time.Now().Add(1 * time.Hour),
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		participantIDs := []shared.UUID[user.User]{}
+		err := ts.EndSession(participantIDs)
+		assert.Equal(t, talksession.ErrSessionNotYetFinished, err)
+	})
+
+	t.Run("既に終了したセッションは再度終了できない", func(t *testing.T) {
+		// 終了予定時刻を過去に設定
+		ts := talksession.NewTalkSession(
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+			"テーマ",
+			nil,
+			nil,
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+			time.Now(),
+			time.Now().Add(-1 * time.Hour), // 過去の時刻を設定
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		err := ts.StartSession()
+		require.NoError(t, err)
+
+		participantIDs := []shared.UUID[user.User]{}
+		err = ts.EndSession(participantIDs)
+		require.NoError(t, err)
+
+		// 2回目の終了はエラー
+		err = ts.EndSession(participantIDs)
+		assert.Equal(t, talksession.ErrSessionAlreadyEnded, err)
+	})
+}
+
+func TestTalkSession_SetReportVisibility(t *testing.T) {
+	t.Run("レポートの表示/非表示を設定できる", func(t *testing.T) {
+		ts := talksession.NewTalkSession(
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+			"テーマ",
+			nil,
+			nil,
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+			time.Now(),
+			time.Now().Add(1 * time.Hour),
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		// デフォルトはfalse
+		assert.False(t, ts.HideReport())
+
+		// 非表示に設定
+		ts.SetReportVisibility(true)
+		assert.True(t, ts.HideReport())
+
+		// 表示に戻す
+		ts.SetReportVisibility(false)
+		assert.False(t, ts.HideReport())
+	})
+}
+
+func TestTalkSession_MarkAsEndProcessed(t *testing.T) {
+	t.Run("終了処理済みフラグを設定できる", func(t *testing.T) {
+		ts := talksession.NewTalkSession(
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+			"テーマ",
+			nil,
+			nil,
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+			time.Now(),
+			time.Now().Add(1 * time.Hour),
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		// デフォルトはfalse
+		assert.False(t, ts.IsEndProcessed())
+
+		// 終了処理済みに設定
+		ts.MarkAsEndProcessed()
+		assert.True(t, ts.IsEndProcessed())
+	})
+}
+
+func TestTalkSession_UpdateRestrictions(t *testing.T) {
+	t.Run("制限を更新できる", func(t *testing.T) {
+		ts := talksession.NewTalkSession(
+			shared.MustParseUUID[talksession.TalkSession]("00000000-0000-0000-0000-000000000001"),
+			"テーマ",
+			nil,
+			nil,
+			shared.MustParseUUID[user.User]("00000000-0000-0000-0000-000000000002"),
+			time.Now(),
+			time.Now().Add(1 * time.Hour),
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		// 初期状態では制限なし
+		assert.Empty(t, ts.RestrictionList())
+
+		// 制限を追加（有効な制限キーを使用）
+		restrictions := []string{"demographics.gender", "demographics.prefecture"}
+		err := ts.UpdateRestrictions(context.Background(), restrictions)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, ts.RestrictionList())
+		assert.NotNil(t, ts.Restrictions())
+	})
+}

--- a/internal/domain/service/session_service.go
+++ b/internal/domain/service/session_service.go
@@ -117,6 +117,7 @@ func (s *sessionService) SwitchOrganization(
 
 	// 新しい組織付きセッションを作成
 	// organizationIDをany型にキャスト
+	orgID := shared.UUID[any](organizationID.UUID())
 	newSess := session.NewSessionWithOrganization(
 		shared.NewUUID[session.Session](),
 		userID,
@@ -124,7 +125,7 @@ func (s *sessionService) SwitchOrganization(
 		session.SESSION_ACTIVE,
 		*session.NewExpiresAt(ctx),
 		clock.Now(ctx),
-		organizationID,
+		&orgID,
 	)
 
 	createdSess, err := s.sessionRepository.Create(ctx, *newSess)

--- a/internal/domain/service/session_service.go
+++ b/internal/domain/service/session_service.go
@@ -117,7 +117,6 @@ func (s *sessionService) SwitchOrganization(
 
 	// 新しい組織付きセッションを作成
 	// organizationIDをany型にキャスト
-	orgID := shared.UUID[any](organizationID.UUID())
 	newSess := session.NewSessionWithOrganization(
 		shared.NewUUID[session.Session](),
 		userID,
@@ -125,7 +124,7 @@ func (s *sessionService) SwitchOrganization(
 		session.SESSION_ACTIVE,
 		*session.NewExpiresAt(ctx),
 		clock.Now(ctx),
-		&orgID,
+		organizationID,
 	)
 
 	createdSess, err := s.sessionRepository.Create(ctx, *newSess)

--- a/internal/infrastructure/di/application.go
+++ b/internal/infrastructure/di/application.go
@@ -87,6 +87,7 @@ func useCaseDeps() []ProvideArg {
 		{organization_usecase.NewCreateOrganizationAliasUseCase, nil},
 		{organization_usecase.NewDeactivateOrganizationAliasUseCase, nil},
 		{organization_usecase.NewListOrganizationAliasesUseCase, nil},
+		{organization_usecase.NewSwitchOrganizationUseCase, nil},
 		{organization_query.NewListOrganizationUsersQuery, nil},
 		{analysis_usecase.NewApplyFeedbackInteractor, nil},
 		{event_processor.NewEventHandlerRegistry, nil},

--- a/internal/presentation/handler/organization_handler.go
+++ b/internal/presentation/handler/organization_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/neko-dream/server/internal/application/query/organization_query"
 	"github.com/neko-dream/server/internal/application/usecase/organization_usecase"
@@ -11,7 +12,9 @@ import (
 	"github.com/neko-dream/server/internal/domain/model/shared"
 	"github.com/neko-dream/server/internal/domain/service"
 	domainservice "github.com/neko-dream/server/internal/domain/service"
+	"github.com/neko-dream/server/internal/infrastructure/http/cookie"
 	"github.com/neko-dream/server/internal/presentation/oas"
+	cookie_utils "github.com/neko-dream/server/pkg/cookie"
 	"go.opentelemetry.io/otel"
 )
 
@@ -30,6 +33,8 @@ type organizationHandler struct {
 	aliasService         *domainservice.OrganizationAliasService
 	authorizationService service.AuthorizationService
 	sessionTokenManager  session.TokenManager
+	switchOrganization   organization_usecase.SwitchOrganizationUseCase
+	cookieManager        cookie.CookieManager
 }
 
 func NewOrganizationHandler(
@@ -47,6 +52,8 @@ func NewOrganizationHandler(
 	aliasService *domainservice.OrganizationAliasService,
 	authorizationService service.AuthorizationService,
 	sessionTokenManager session.TokenManager,
+	switchOrganization organization_usecase.SwitchOrganizationUseCase,
+	cookieManager cookie.CookieManager,
 ) oas.OrganizationHandler {
 	return &organizationHandler{
 		create:               create,
@@ -63,6 +70,8 @@ func NewOrganizationHandler(
 		aliasService:         aliasService,
 		authorizationService: authorizationService,
 		sessionTokenManager:  sessionTokenManager,
+		switchOrganization:   switchOrganization,
+		cookieManager:        cookieManager,
 	}
 }
 
@@ -329,4 +338,21 @@ func (o *organizationHandler) GetOrganizationUsers(ctx context.Context) (oas.Get
 	return &oas.GetOrganizationUsersOK{
 		Users: organizationUsers,
 	}, nil
+}
+
+// SwitchOrganization 組織を切り替える
+func (o *organizationHandler) SwitchOrganization(ctx context.Context, params oas.SwitchOrganizationParams) (oas.SwitchOrganizationRes, error) {
+	ctx, span := otel.Tracer("handler").Start(ctx, "organizationHandler.SwitchOrganization")
+	defer span.End()
+
+	output, err := o.switchOrganization.Execute(ctx, organization_usecase.SwitchOrganizationUseCaseInput{
+		Code: params.Code,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res := oas.SwitchOrganizationOK{}
+	res.SetSetCookie(cookie_utils.EncodeCookies([]*http.Cookie{o.cookieManager.CreateSessionCookie(output.SessionTokenStr)}))
+	return &res, nil
 }

--- a/internal/presentation/handler/organization_handler.go
+++ b/internal/presentation/handler/organization_handler.go
@@ -345,8 +345,15 @@ func (o *organizationHandler) SwitchOrganization(ctx context.Context, params oas
 	ctx, span := otel.Tracer("handler").Start(ctx, "organizationHandler.SwitchOrganization")
 	defer span.End()
 
+	authCtx, err := o.authorizationService.RequireAuthentication(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	output, err := o.switchOrganization.Execute(ctx, organization_usecase.SwitchOrganizationUseCaseInput{
-		Code: params.Code,
+		Code:      params.Code,
+		UserID:    authCtx.UserID,
+		SessionID: authCtx.SessionID,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/presentation/oas/oas_handlers_gen.go
+++ b/internal/presentation/oas/oas_handlers_gen.go
@@ -9956,6 +9956,162 @@ func (s *Server) handleSwipeOpinionsRequest(args [1]string, argsEscaped bool, w 
 	}
 }
 
+// handleSwitchOrganizationRequest handles switchOrganization operation.
+//
+// 組織切り替え.
+//
+// POST /organizations/switch/{code}
+func (s *Server) handleSwitchOrganizationRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("switchOrganization"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/organizations/switch/{code}"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "SwitchOrganization",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		attrOpt := metric.WithAttributeSet(labeler.AttributeSet())
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributeSet(labeler.AttributeSet()))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "SwitchOrganization",
+			ID:   "switchOrganization",
+		}
+	)
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			sctx, ok, err := s.securityCookieAuth(ctx, "SwitchOrganization", r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "CookieAuth",
+					Err:              err,
+				}
+				defer recordError("Security:CookieAuth", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 0
+				ctx = sctx
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			err = &ogenerrors.SecurityError{
+				OperationContext: opErrContext,
+				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
+			}
+			defer recordError("Security", err)
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+	}
+	params, err := decodeSwitchOrganizationParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var response SwitchOrganizationRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "SwitchOrganization",
+			OperationSummary: "組織切り替え",
+			OperationID:      "switchOrganization",
+			Body:             nil,
+			Params: middleware.Parameters{
+				{
+					Name: "code",
+					In:   "path",
+				}: params.Code,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = SwitchOrganizationParams
+			Response = SwitchOrganizationRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackSwitchOrganizationParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.SwitchOrganization(ctx, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.SwitchOrganization(ctx, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeSwitchOrganizationResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handleTalkSessionAnalysisRequest handles talkSessionAnalysis operation.
 //
 // 分析結果一覧.

--- a/internal/presentation/oas/oas_interfaces_gen.go
+++ b/internal/presentation/oas/oas_interfaces_gen.go
@@ -249,6 +249,10 @@ type SwipeOpinionsRes interface {
 	swipeOpinionsRes()
 }
 
+type SwitchOrganizationRes interface {
+	switchOrganizationRes()
+}
+
 type TalkSessionAnalysisRes interface {
 	talkSessionAnalysisRes()
 }

--- a/internal/presentation/oas/oas_json_gen.go
+++ b/internal/presentation/oas/oas_json_gen.go
@@ -14493,6 +14493,94 @@ func (s *SwipeOpinionsOK) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *SwitchOrganizationBadRequest) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *SwitchOrganizationBadRequest) encodeFields(e *jx.Encoder) {
+}
+
+var jsonFieldsNameOfSwitchOrganizationBadRequest = [0]string{}
+
+// Decode decodes SwitchOrganizationBadRequest from json.
+func (s *SwitchOrganizationBadRequest) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode SwitchOrganizationBadRequest to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		default:
+			return d.Skip()
+		}
+	}); err != nil {
+		return errors.Wrap(err, "decode SwitchOrganizationBadRequest")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *SwitchOrganizationBadRequest) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *SwitchOrganizationBadRequest) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *SwitchOrganizationInternalServerError) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *SwitchOrganizationInternalServerError) encodeFields(e *jx.Encoder) {
+}
+
+var jsonFieldsNameOfSwitchOrganizationInternalServerError = [0]string{}
+
+// Decode decodes SwitchOrganizationInternalServerError from json.
+func (s *SwitchOrganizationInternalServerError) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode SwitchOrganizationInternalServerError to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		default:
+			return d.Skip()
+		}
+	}); err != nil {
+		return errors.Wrap(err, "decode SwitchOrganizationInternalServerError")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *SwitchOrganizationInternalServerError) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *SwitchOrganizationInternalServerError) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *TalkSession) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)

--- a/internal/presentation/oas/oas_parameters_gen.go
+++ b/internal/presentation/oas/oas_parameters_gen.go
@@ -4643,6 +4643,71 @@ func decodeSwipeOpinionsParams(args [1]string, argsEscaped bool, r *http.Request
 	return params, nil
 }
 
+// SwitchOrganizationParams is parameters of switchOrganization operation.
+type SwitchOrganizationParams struct {
+	Code string
+}
+
+func unpackSwitchOrganizationParams(packed middleware.Parameters) (params SwitchOrganizationParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "code",
+			In:   "path",
+		}
+		params.Code = packed[key].(string)
+	}
+	return params
+}
+
+func decodeSwitchOrganizationParams(args [1]string, argsEscaped bool, r *http.Request) (params SwitchOrganizationParams, _ error) {
+	// Decode path: code.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "code",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.Code = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "code",
+			In:   "path",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
 // TalkSessionAnalysisParams is parameters of talkSessionAnalysis operation.
 type TalkSessionAnalysisParams struct {
 	TalkSessionID string

--- a/internal/presentation/oas/oas_router_gen.go
+++ b/internal/presentation/oas/oas_router_gen.go
@@ -1035,6 +1035,34 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								}
 
 								elem = origElem
+							case 's': // Prefix: "switch/"
+								origElem := elem
+								if l := len("switch/"); len(elem) >= l && elem[0:l] == "switch/" {
+									elem = elem[l:]
+								} else {
+									break
+								}
+
+								// Param: "code"
+								// Leaf parameter
+								args[0] = elem
+								elem = ""
+
+								if len(elem) == 0 {
+									// Leaf node.
+									switch r.Method {
+									case "POST":
+										s.handleSwitchOrganizationRequest([1]string{
+											args[0],
+										}, elemIsEscaped, w, r)
+									default:
+										s.notAllowed(w, r, "POST")
+									}
+
+									return
+								}
+
+								elem = origElem
 							case 'u': // Prefix: "users"
 								origElem := elem
 								if l := len("users"); len(elem) >= l && elem[0:l] == "users" {
@@ -3128,6 +3156,36 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									}
 
 									elem = origElem
+								}
+
+								elem = origElem
+							case 's': // Prefix: "switch/"
+								origElem := elem
+								if l := len("switch/"); len(elem) >= l && elem[0:l] == "switch/" {
+									elem = elem[l:]
+								} else {
+									break
+								}
+
+								// Param: "code"
+								// Leaf parameter
+								args[0] = elem
+								elem = ""
+
+								if len(elem) == 0 {
+									// Leaf node.
+									switch method {
+									case "POST":
+										r.name = "SwitchOrganization"
+										r.summary = "組織切り替え"
+										r.operationID = "switchOrganization"
+										r.pathPattern = "/organizations/switch/{code}"
+										r.args = args
+										r.count = 1
+										return r, true
+									default:
+										return
+									}
 								}
 
 								elem = origElem

--- a/internal/presentation/oas/oas_schemas_gen.go
+++ b/internal/presentation/oas/oas_schemas_gen.go
@@ -6089,6 +6089,31 @@ func (s *SwipeOpinionsOK) SetRemainingCount(val int) {
 
 func (*SwipeOpinionsOK) swipeOpinionsRes() {}
 
+type SwitchOrganizationBadRequest struct{}
+
+func (*SwitchOrganizationBadRequest) switchOrganizationRes() {}
+
+type SwitchOrganizationInternalServerError struct{}
+
+func (*SwitchOrganizationInternalServerError) switchOrganizationRes() {}
+
+// SwitchOrganizationOK is response for SwitchOrganization operation.
+type SwitchOrganizationOK struct {
+	SetCookie []string
+}
+
+// GetSetCookie returns the value of SetCookie.
+func (s *SwitchOrganizationOK) GetSetCookie() []string {
+	return s.SetCookie
+}
+
+// SetSetCookie sets the value of SetCookie.
+func (s *SwitchOrganizationOK) SetSetCookie(val []string) {
+	s.SetCookie = val
+}
+
+func (*SwitchOrganizationOK) switchOrganizationRes() {}
+
 // Ref: #/components/schemas/TalkSession
 type TalkSession struct {
 	// トークセッションID.

--- a/internal/presentation/oas/oas_server_gen.go
+++ b/internal/presentation/oas/oas_server_gen.go
@@ -344,6 +344,12 @@ type OrganizationHandler interface {
 	//
 	// POST /organizations/invite_user
 	InviteOrganizationForUser(ctx context.Context, req *InviteOrganizationForUserReq) (InviteOrganizationForUserRes, error)
+	// SwitchOrganization implements switchOrganization operation.
+	//
+	// 組織切り替え.
+	//
+	// POST /organizations/switch/{code}
+	SwitchOrganization(ctx context.Context, params SwitchOrganizationParams) (SwitchOrganizationRes, error)
 	// ValidateOrganizationCode implements validateOrganizationCode operation.
 	//
 	// 組織コード検証.

--- a/internal/presentation/oas/oas_unimplemented_gen.go
+++ b/internal/presentation/oas/oas_unimplemented_gen.go
@@ -645,6 +645,15 @@ func (UnimplementedHandler) SwipeOpinions(ctx context.Context, params SwipeOpini
 	return r, ht.ErrNotImplemented
 }
 
+// SwitchOrganization implements switchOrganization operation.
+//
+// 組織切り替え.
+//
+// POST /organizations/switch/{code}
+func (UnimplementedHandler) SwitchOrganization(ctx context.Context, params SwitchOrganizationParams) (r SwitchOrganizationRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // TalkSessionAnalysis implements talkSessionAnalysis operation.
 //
 // 分析結果一覧.

--- a/internal/presentation/oas/oas_validators_gen.go
+++ b/internal/presentation/oas/oas_validators_gen.go
@@ -1550,6 +1550,29 @@ func (s *SwipeOpinionsOK) Validate() error {
 	return nil
 }
 
+func (s *SwitchOrganizationOK) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if s.SetCookie == nil {
+			return errors.New("nil is invalid value")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "SetCookie",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *TalkSession) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -81,7 +81,7 @@ if ! wait_for_server 3000; then
 fi
 
 print_success "\n=== E2Eテスト実行中 ==="
-runn run $TEST_PATH --verbose --debug
+runn run $TEST_PATH --verbose
 
 EXIT_CODE=$?
 

--- a/static/oas/openapi.yaml
+++ b/static/oas/openapi.yaml
@@ -1651,6 +1651,42 @@ paths:
                 - displayID
                 - role
       x-ogen-operation-group: Organization
+  /organizations/switch/{code}:
+    post:
+      operationId: switchOrganization
+      summary: 組織切り替え
+      parameters:
+        - name: code
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          headers:
+            Set-Cookie:
+              required: true
+              description: SessionID
+              schema:
+                type: array
+                items:
+                  type: string
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                type: object
+      tags:
+        - organization
+      x-ogen-operation-group: Organization
   /organizations/users:
     get:
       operationId: getOrganizationUsers

--- a/tsp/routes/organization.tsp
+++ b/tsp/routes/organization.tsp
@@ -54,6 +54,26 @@ namespace kotohiro {
     @body body: {};
   };
 
+  @tag("organization")
+  @extension("x-ogen-operation-group", "Organization")
+  @route("/organizations/switch/{code}")
+  @post
+  @summary("組織切り替え")
+  op switchOrganization(
+    @path code: string
+  ) : {
+    /**
+     * SessionID
+     */
+    @header("Set-Cookie") SetCookie: string[];
+  } | {
+    @statusCode statusCode: 400;
+    @body body: {};
+  } | {
+    @statusCode statusCode: 500;
+    @body body: {};
+  };
+
   /**
    * Role
    * - 10: SuperAdmin


### PR DESCRIPTION
<!--
GitHub Copilot Reviewerへの指示: コードレビューしコメントする際は**必ず日本語**で行ってください。英語は絶対に使用しないでください。
-->

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo] (in my opinion)
[nits](nitpick)
[ask]
[fyi]
-->

<!--
データフロー図の生成指示:
このPRで変更されたコードのデータフローやプロセスフローをMermaid記法で図示してください。
以下のような図を生成してください：
1. コンポーネント間のデータの流れ
2. 処理の順序や条件分岐
3. 変更によって影響を受ける部分の関係性

例：
  ```
  graph TD
    A[入力データ] --&gt; B{処理モジュール}
    B --&gt; |条件1| C[出力1]
    B --&gt; |条件2| D[出力2]
    D --&gt; E[後続処理]
  ```
-->
<!-- for GitHub Copilot review rule -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 組織切り替えに対応：コード指定で現在の組織を切り替え可能になりました。
  - 切り替え成功時に新しいセッションが発行され、ブラウザにセッションクッキーが設定されます。
  - 新しいエンドポイント：POST /organizations/switch/{code}
- **雑務**
  - E2E テスト実行スクリプトから --debug フラグを削除し、実行ログを簡素化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->